### PR TITLE
kotlin-arrow: small improvement

### DIFF
--- a/kotlin-arrow/build.gradle.kts
+++ b/kotlin-arrow/build.gradle.kts
@@ -21,8 +21,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     implementation("io.ktor:ktor-client-core:2.2.1")
     implementation("io.ktor:ktor-client-java:2.2.1")
-    implementation("io.arrow-kt:arrow-fx-coroutines:1.0.1")
-    implementation("io.arrow-kt:arrow-fx-stm:1.0.1")
+    implementation("io.arrow-kt:arrow-fx-coroutines:1.1.6-alpha.28")
 
     testImplementation("io.kotest:kotest-runner-junit5:5.5.4")
     testImplementation("io.kotest:kotest-assertions-core:5.5.4")

--- a/kotlin-arrow/src/main/kotlin/Main.kt
+++ b/kotlin-arrow/src/main/kotlin/Main.kt
@@ -1,201 +1,171 @@
+import arrow.core.Either
 import arrow.core.merge
+import arrow.fx.coroutines.ResourceScope
+import arrow.fx.coroutines.parMap
 import arrow.fx.coroutines.raceN
+import arrow.fx.coroutines.resourceScope
 import io.ktor.client.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.time.delay
-import java.io.IOException
 import java.time.Duration
 import java.time.Instant
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.withTimeout
 
+suspend fun <A> ignoreException(block: suspend () -> A): A =
+  Either.catch { block() }.mapLeft { awaitCancellation() }.merge()
 
-val client = HttpClient {
-    install(HttpTimeout)
-}
+suspend fun ResourceScope.client(): HttpClient =
+  install({
+    HttpClient {
+      install(HttpTimeout)
+    }
+  }) { client, _ -> client.close() }
 
 // Note: Intentionally, only url handling code is shared across scenarios
+suspend fun HttpClient.scenario1(url: (Int) -> String): String =
+  raceN({ get(url(1)) }, { get(url(1)) }).merge().bodyAsText()
 
-suspend fun scenario1(url: (Int) -> String): String =
-    raceN({
-        client.get(url(1))
-    }, {
-        client.get(url(1))
-    }).merge().bodyAsText()
+suspend fun HttpClient.scenario2(url: (Int) -> String): String {
+  suspend fun req(): String =
+    ignoreException { get(url(2)).bodyAsText() }
 
-
-suspend fun scenario2(url: (Int) -> String): String {
-    suspend fun req(): String =
-        try {
-            client.get(url(2)).bodyAsText()
-        } catch (e: IOException) {
-            awaitCancellation()
-        }
-
-    return raceN({
-        req()
-    }, {
-        req()
-    }).merge()
-
+  return raceN({
+    req()
+  }, {
+    req()
+  }).merge()
 }
-
 
 // note: plain Kotlin, not Arrow
-suspend fun scenario3(url: (Int) -> String): String = coroutineScope {
-    val reqs = List(10_000) {
-        async {
-            client.get(url(3))
-        }
+suspend fun HttpClient.scenario3(url: (Int) -> String): String = coroutineScope {
+  val reqs = List(10_000) {
+    async {
+      get(url(3))
     }
+  }
 
-    val done = select {
-        reqs.map { req ->
-            req.onAwait.invoke {
-                it.bodyAsText()
-            }
-        }
+  val done = select {
+    reqs.map { req ->
+      req.onAwait.invoke {
+        it.bodyAsText()
+      }
     }
+  }
 
-    reqs.forEach {
-        it.cancelAndJoin()
-    }
+  reqs.forEach {
+    it.cancelAndJoin()
+  }
 
-    done
+  done
 }
 
 
-suspend fun scenario4(url: (Int) -> String): String =
-    raceN({
-        // todo: withTimeout(Duration.ofSeconds(1)) {
-        try {
-            client.get(url(4)) {
-                timeout {
-                    requestTimeoutMillis = 1000
-                }
-            }
-        } catch (e: Exception) {
-            awaitCancellation()
-        }
-    }, {
-        client.get(url(4))
-    }).merge().bodyAsText()
+suspend fun HttpClient.scenario4(url: (Int) -> String): String =
+  raceN({
+    ignoreException { withTimeout(1.seconds) { get(url(4)) } }
+  }, {
+    get(url(4))
+  }).merge().bodyAsText()
 
-
-suspend fun scenario5(url: (Int) -> String): String {
-    suspend fun req(): String =
-        try {
-            val resp = client.get(url(5))
-            require(resp.status.isSuccess())
-            resp.bodyAsText()
-        } catch (e: IllegalArgumentException) {
-            awaitCancellation()
-        }
-
-    return raceN({
-        req()
-    }, {
-        req()
-    }).merge()
-}
-
-
-suspend fun scenario6(url: (Int) -> String): String {
-    suspend fun req(): String =
-        try {
-            val resp = client.get(url(6))
-            require(resp.status.isSuccess())
-            resp.bodyAsText()
-        } catch (e: IllegalArgumentException) {
-            awaitCancellation()
-        }
-
-    return raceN({
-        req()
-    }, {
-        req()
-    }, {
-        req()
-    }).fold({ it }, { it }, { it })
-}
-
-
-suspend fun scenario7(url: (Int) -> String): String =
-    raceN({
-        client.get(url(7))
-    }, {
-        delay(Duration.ofSeconds(3))
-        client.get(url(7))
-    }).merge().bodyAsText()
-
-
-suspend fun scenario8(url: (Int) -> String): String {
-    suspend fun req(): String {
-        val id = client.get(url(8) + "?open").bodyAsText()
-        try {
-            val resp = client.get(url(8) + "?use=$id")
-            require(resp.status.isSuccess())
-            return resp.bodyAsText()
-        } finally {
-            client.get(url(8) + "?close=$id").bodyAsText()
-        }
+suspend fun HttpClient.scenario5(url: (Int) -> String): String {
+  suspend fun req(): String =
+    ignoreException {
+      val resp = get(url(5))
+      require(resp.status.isSuccess())
+      resp.bodyAsText()
     }
 
-    return raceN({
-        try {
-            req()
-        } catch (e: Exception) {
-            awaitCancellation()
-        }
-    }, {
-        try {
-            req()
-        } catch (e: Exception) {
-            awaitCancellation()
-        }
-    }).merge()
+  return raceN({
+    req()
+  }, {
+    req()
+  }).merge()
+}
+
+suspend fun HttpClient.scenario6(url: (Int) -> String): String {
+  suspend fun req(): String =
+    ignoreException {
+      val resp = get(url(6))
+      require(resp.status.isSuccess())
+      resp.bodyAsText()
+    }
+
+  return raceN({
+    req()
+  }, {
+    req()
+  }, {
+    req()
+  }).fold({ it }, { it }, { it })
 }
 
 
-suspend fun scenario9(url: (Int) -> String): String {
-    suspend fun req(): Pair<Instant, String>? {
-        val resp = client.get(url(9))
-        return if (resp.status.isSuccess()) {
-            Instant.now() to resp.bodyAsText()
-        } else {
-            null
-        }
-    }
+suspend fun HttpClient.scenario7(url: (Int) -> String): String =
+  raceN({
+    get(url(7))
+  }, {
+    delay(Duration.ofSeconds(3))
+    get(url(7))
+  }).merge().bodyAsText()
 
-    return coroutineScope {
-        val letters = List(10) {
-            async {
-                req()
-            }
-        }.awaitAll()
-
-        letters.filterNotNull().sortedBy { it.first }.joinToString("") { it.second }
+suspend fun HttpClient.scenario8(url: (Int) -> String): String {
+  suspend fun req(): String {
+    val id = get(url(8) + "?open").bodyAsText()
+    try {
+      val resp = get(url(8) + "?use=$id")
+      require(resp.status.isSuccess())
+      return resp.bodyAsText()
+    } finally {
+      get(url(8) + "?close=$id").bodyAsText()
     }
+  }
+
+  return raceN({
+    ignoreException { req() }
+  }, {
+    ignoreException { req() }
+  }).merge()
 }
 
+suspend fun HttpClient.scenario9(url: (Int) -> String): String {
+  suspend fun req(): Pair<Instant, String>? =
+    get(url(9)).takeIf { it.status.isSuccess() }
+      ?.let { resp -> Instant.now() to resp.bodyAsText() }
 
-val scenarios = listOf(::scenario1, ::scenario2, ::scenario3, ::scenario4, ::scenario5, ::scenario6, ::scenario7, ::scenario8, ::scenario9)
+  return (0..10)
+    .parMap { req() }
+    .filterNotNull()
+    .sortedBy { it.first }
+    .joinToString("") { it.second }
+}
+
+fun HttpClient.scenarios() = listOf(
+  ::scenario1,
+  ::scenario2,
+  ::scenario3,
+  ::scenario4,
+  ::scenario5,
+  ::scenario6,
+  ::scenario7,
+  ::scenario8,
+  ::scenario9
+)
 //val scenarios = listOf(::scenario8)
 
-suspend fun results(url: (Int) -> String) = scenarios.map {
-    coroutineScope {
-        async { it(url) }
-    }
-}.awaitAll()
+suspend fun results(url: (Int) -> String) = resourceScope {
+  client().scenarios().parMap { it(url) }
+}
 
 suspend fun main() {
-    fun url(scenario: Int) = "http://localhost:8080/$scenario"
-    println(results(::url))
+  fun url(scenario: Int) = "http://localhost:8080/$scenario"
+  println(results(::url))
 }


### PR DESCRIPTION
Arrow Fx Coroutines is missing a collection/arity-n racer for racers of the same type `A`.

Using `1.1.6-alpha.28`, which will soon be released as `1.2.0` as the final `1.x.x` version before `2.x.x`.
`parMap` is named `parTraverse` in `1.1.x` but is being renamed to be more user-friendly. I thought it made more sense to use `2.x.x` compatibel API name rather than a name that'll be deprecated soon. The signatures are the same.

Also updated to use `ResoureScope` for `HttpClient` so it gets closed properly 😉