### PR TITLE
Go: Wait 3 seconds for scenario 7

### DIFF
--- a/go-stdlib/main.go
+++ b/go-stdlib/main.go
@@ -175,7 +175,7 @@ func scenario7(scenarioURL func(int) string) string {
 	}
 
 	go httpTextToChannel()
-	time.Sleep(2 * time.Second)
+	time.Sleep(3 * time.Second)
 	go httpTextToChannel()
 
 	return <-result


### PR DESCRIPTION
Realized I made a mistake for scenario 7.

I changed it to wait 2 seconds, because that's how long the server was waiting, but it looks like that may be to allow for a 1 second margin, as the main README says to wait 3 seconds.