### PR TITLE
Swift + async/await: Run scenario 3 last.

### DIFF
--- a/swift-async/Sources/EasyRacer/EasyRacer.swift
+++ b/swift-async/Sources/EasyRacer/EasyRacer.swift
@@ -106,11 +106,6 @@ public struct EasyRacer {
             
             return await group.first { $0 != nil }.flatMap { $0 }
         }
-        // After this scenario runs, subsequent seems more likely to fail
-        // Current theory is that after the tasks in the task group are cancelled
-        // it's taking some time for all 10k HTTP connections to disconnect.
-        // 30-second pause seems to help with this.
-        try? await Task.sleep(nanoseconds: 30_000_000_000)
         
         return result
     }
@@ -345,13 +340,13 @@ public struct EasyRacer {
         [
             (1, await scenario1()),
             (2, await scenario2()),
-            (3, await scenario3()),
             (4, await scenario4()),
             (5, await scenario5()),
             (6, await scenario6()),
             (7, await scenario7()),
             (8, await scenario8()),
             (9, await scenario9()),
+            (3, await scenario3()), // This has to come last, as it frequently causes other scenarios to fail
         ]
     }
     


### PR DESCRIPTION
I thought I had fixed the issue where scenario 3 was causing other scenarios to fail, but looks like that is not the case. Going back to running it last.