### PR TITLE
Add "EXPOSE 8080" to scenario-server Dockerfile

### DIFF
--- a/go-stdlib/main_test.go
+++ b/go-stdlib/main_test.go
@@ -11,7 +11,7 @@ import (
 func TestScenarios(t *testing.T) {
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{
-		Image:        "ghcr.io/jamesward/easyracer",
+		Image:        "ghcr.io/jackgene/easyracer",
 		ExposedPorts: []string{"8080/tcp"},
 		WaitingFor:   wait.ForHTTP("/").WithPort("8080"),
 	}

--- a/go-stdlib/main_test.go
+++ b/go-stdlib/main_test.go
@@ -11,7 +11,7 @@ import (
 func TestScenarios(t *testing.T) {
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{
-		Image:        "ghcr.io/jackgene/easyracer",
+		Image:        "ghcr.io/jamesward/easyracer",
 		ExposedPorts: []string{"8080/tcp"},
 		WaitingFor:   wait.ForHTTP("/").WithPort("8080"),
 	}

--- a/scenario-server/Dockerfile
+++ b/scenario-server/Dockerfile
@@ -65,3 +65,5 @@ WORKDIR /tmp
 COPY --from=builder /app/target/graalvm-native-image/easyracer-server /easyracer-server
 
 ENTRYPOINT ["/easyracer-server"]
+
+EXPOSE 8080


### PR DESCRIPTION
Hey James,
Not really sure why, but without an explicit:
```
EXPOSE 8080
```

[testcontainers-node](https://github.com/testcontainers/testcontainers-node) doesn't seem to be able to load up the scenario server (I believe the image is running, but port doesn't get forwarded).

Example where it fails: https://github.com/jackgene/easyracer/actions/runs/4395213472/jobs/7697201481
Adding `EXPOSE 8080` fixes: https://github.com/jackgene/easyracer/actions/runs/4395485823/jobs/7698773563

This change seems to resolve it, though I'm not sure if there's a reason we should not include it. If you have concerns, I can also attempt to fix it in `testcontainers-node`, as the image is fine with every other `testcontainers` implementation after all.

I did do a [quick regression test](https://github.com/jackgene/easyracer/commit/b78df06e6688405706d6c3f97a4d41f0847ec7ff) and verified that the [Java+Loom](https://github.com/jackgene/easyracer/actions/runs/4396395516), [Swift+Dispatch](https://github.com/jackgene/easyracer/actions/runs/4396395517) and [Go](https://github.com/jackgene/easyracer/actions/runs/4396395515) implementations are still working.
