### PR TITLE
Extracted Javascript interop into Ports module.

### DIFF
--- a/elm-worker/src/EasyRacer/Ports.elm
+++ b/elm-worker/src/EasyRacer/Ports.elm
@@ -1,0 +1,21 @@
+port module EasyRacer.Ports exposing (sendResult)
+
+
+type alias ScenarioResult =
+    { isError : Bool
+    , value : String
+    }
+
+
+port sendResult_ : ScenarioResult -> Cmd msg
+
+
+sendResult : Result String String -> Cmd msg
+sendResult result =
+    sendResult_ <|
+        case result of
+            Ok value ->
+                { isError = False, value = value }
+
+            Err error ->
+                { isError = True, value = error }

--- a/elm-worker/src/EasyRacer/Scenario1.elm
+++ b/elm-worker/src/EasyRacer/Scenario1.elm
@@ -1,17 +1,9 @@
-port module EasyRacer.Scenario1 exposing (main)
+module EasyRacer.Scenario1 exposing (main)
 
+import EasyRacer.Ports as Ports
 import Http
 import Platform exposing (Program)
 import Set exposing (Set)
-
-
-type alias ScenarioResult =
-    { isError : Bool
-    , value : String
-    }
-
-
-port sendResult_ : ScenarioResult -> Cmd msg
 
 
 type alias Flags =
@@ -56,17 +48,6 @@ init baseUrl =
     )
 
 
-sendResult : Result String String -> Cmd Msg
-sendResult result =
-    sendResult_ <|
-        case result of
-            Ok value ->
-                { isError = False, value = value }
-
-            Err error ->
-                { isError = True, value = error }
-
-
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -88,7 +69,7 @@ update msg model =
 
                         returnResult : Cmd Msg
                         returnResult =
-                            Ok bodyText |> sendResult
+                            Ok bodyText |> Ports.sendResult
                     in
                     returnResult :: cancellations |> Cmd.batch
 
@@ -97,7 +78,7 @@ update msg model =
                         Cmd.none
 
                     else
-                        Err "all requests completed without a single success response" |> sendResult
+                        Err "all requests completed without a single success response" |> Ports.sendResult
             )
 
 

--- a/elm-worker/src/EasyRacer/Scenario2.elm
+++ b/elm-worker/src/EasyRacer/Scenario2.elm
@@ -1,17 +1,9 @@
-port module EasyRacer.Scenario2 exposing (main)
+module EasyRacer.Scenario2 exposing (main)
 
+import EasyRacer.Ports as Ports
 import Http
 import Platform exposing (Program)
 import Set exposing (Set)
-
-
-type alias ScenarioResult =
-    { isError : Bool
-    , value : String
-    }
-
-
-port sendResult_ : ScenarioResult -> Cmd msg
 
 
 type alias Flags =
@@ -56,17 +48,6 @@ init baseUrl =
     )
 
 
-sendResult : Result String String -> Cmd Msg
-sendResult result =
-    sendResult_ <|
-        case result of
-            Ok value ->
-                { isError = False, value = value }
-
-            Err error ->
-                { isError = True, value = error }
-
-
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -88,7 +69,7 @@ update msg model =
 
                         returnResult : Cmd Msg
                         returnResult =
-                            Ok bodyText |> sendResult
+                            Ok bodyText |> Ports.sendResult
                     in
                     returnResult :: cancellations |> Cmd.batch
 
@@ -97,7 +78,7 @@ update msg model =
                         Cmd.none
 
                     else
-                        Err "all requests completed without a single success response" |> sendResult
+                        Err "all requests completed without a single success response" |> Ports.sendResult
             )
 
 

--- a/elm-worker/src/EasyRacer/Scenario3.elm
+++ b/elm-worker/src/EasyRacer/Scenario3.elm
@@ -1,17 +1,9 @@
-port module EasyRacer.Scenario3 exposing (main)
+module EasyRacer.Scenario3 exposing (main)
 
+import EasyRacer.Ports as Ports
 import Http
 import Platform exposing (Program)
 import Set exposing (Set)
-
-
-type alias ScenarioResult =
-    { isError : Bool
-    , value : String
-    }
-
-
-port sendResult_ : ScenarioResult -> Cmd msg
 
 
 type alias Flags =
@@ -57,17 +49,6 @@ init baseUrl =
     )
 
 
-sendResult : Result String String -> Cmd Msg
-sendResult result =
-    sendResult_ <|
-        case result of
-            Ok value ->
-                { isError = False, value = value }
-
-            Err error ->
-                { isError = True, value = error }
-
-
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -89,7 +70,7 @@ update msg model =
 
                         returnResult : Cmd Msg
                         returnResult =
-                            Ok bodyText |> sendResult
+                            Ok bodyText |> Ports.sendResult
                     in
                     returnResult :: cancellations |> Cmd.batch
 
@@ -98,7 +79,7 @@ update msg model =
                         Cmd.none
 
                     else
-                        Err "all requests completed without a single success response" |> sendResult
+                        Err "all requests completed without a single success response" |> Ports.sendResult
             )
 
 

--- a/elm-worker/src/EasyRacer/Scenario4.elm
+++ b/elm-worker/src/EasyRacer/Scenario4.elm
@@ -1,17 +1,9 @@
-port module EasyRacer.Scenario4 exposing (main)
+module EasyRacer.Scenario4 exposing (main)
 
+import EasyRacer.Ports as Ports
 import Http
 import Platform exposing (Program)
 import Set exposing (Set)
-
-
-type alias ScenarioResult =
-    { isError : Bool
-    , value : String
-    }
-
-
-port sendResult_ : ScenarioResult -> Cmd msg
 
 
 type alias Flags =
@@ -59,17 +51,6 @@ init baseUrl =
     )
 
 
-sendResult : Result String String -> Cmd Msg
-sendResult result =
-    sendResult_ <|
-        case result of
-            Ok value ->
-                { isError = False, value = value }
-
-            Err error ->
-                { isError = True, value = error }
-
-
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -91,7 +72,7 @@ update msg model =
 
                         returnResult : Cmd Msg
                         returnResult =
-                            Ok bodyText |> sendResult
+                            Ok bodyText |> Ports.sendResult
                     in
                     returnResult :: cancellations |> Cmd.batch
 
@@ -100,7 +81,7 @@ update msg model =
                         Cmd.none
 
                     else
-                        Err "all requests completed without a single success response" |> sendResult
+                        Err "all requests completed without a single success response" |> Ports.sendResult
             )
 
 

--- a/elm-worker/src/EasyRacer/Scenario5.elm
+++ b/elm-worker/src/EasyRacer/Scenario5.elm
@@ -1,17 +1,9 @@
-port module EasyRacer.Scenario5 exposing (main)
+module EasyRacer.Scenario5 exposing (main)
 
+import EasyRacer.Ports as Ports
 import Http
 import Platform exposing (Program)
 import Set exposing (Set)
-
-
-type alias ScenarioResult =
-    { isError : Bool
-    , value : String
-    }
-
-
-port sendResult_ : ScenarioResult -> Cmd msg
 
 
 type alias Flags =
@@ -56,17 +48,6 @@ init baseUrl =
     )
 
 
-sendResult : Result String String -> Cmd Msg
-sendResult result =
-    sendResult_ <|
-        case result of
-            Ok value ->
-                { isError = False, value = value }
-
-            Err error ->
-                { isError = True, value = error }
-
-
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -88,7 +69,7 @@ update msg model =
 
                         returnResult : Cmd Msg
                         returnResult =
-                            Ok bodyText |> sendResult
+                            Ok bodyText |> Ports.sendResult
                     in
                     returnResult :: cancellations |> Cmd.batch
 
@@ -97,7 +78,7 @@ update msg model =
                         Cmd.none
 
                     else
-                        Err "all requests completed without a single success response" |> sendResult
+                        Err "all requests completed without a single success response" |> Ports.sendResult
             )
 
 

--- a/elm-worker/src/EasyRacer/Scenario6.elm
+++ b/elm-worker/src/EasyRacer/Scenario6.elm
@@ -1,17 +1,9 @@
-port module EasyRacer.Scenario6 exposing (main)
+module EasyRacer.Scenario6 exposing (main)
 
+import EasyRacer.Ports as Ports
 import Http
 import Platform exposing (Program)
 import Set exposing (Set)
-
-
-type alias ScenarioResult =
-    { isError : Bool
-    , value : String
-    }
-
-
-port sendResult_ : ScenarioResult -> Cmd msg
 
 
 type alias Flags =
@@ -56,17 +48,6 @@ init baseUrl =
     )
 
 
-sendResult : Result String String -> Cmd Msg
-sendResult result =
-    sendResult_ <|
-        case result of
-            Ok value ->
-                { isError = False, value = value }
-
-            Err error ->
-                { isError = True, value = error }
-
-
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -88,7 +69,7 @@ update msg model =
 
                         returnResult : Cmd Msg
                         returnResult =
-                            Ok bodyText |> sendResult
+                            Ok bodyText |> Ports.sendResult
                     in
                     returnResult :: cancellations |> Cmd.batch
 
@@ -97,7 +78,7 @@ update msg model =
                         Cmd.none
 
                     else
-                        Err "all requests completed without a single success response" |> sendResult
+                        Err "all requests completed without a single success response" |> Ports.sendResult
             )
 
 

--- a/elm-worker/src/EasyRacer/Scenario7.elm
+++ b/elm-worker/src/EasyRacer/Scenario7.elm
@@ -1,19 +1,11 @@
-port module EasyRacer.Scenario7 exposing (main)
+module EasyRacer.Scenario7 exposing (main)
 
+import EasyRacer.Ports as Ports
 import Http
 import Platform exposing (Program)
 import Process
 import Set exposing (Set)
 import Task
-
-
-type alias ScenarioResult =
-    { isError : Bool
-    , value : String
-    }
-
-
-port sendResult_ : ScenarioResult -> Cmd msg
 
 
 type alias Flags =
@@ -75,17 +67,6 @@ init baseUrl =
     )
 
 
-sendResult : Result String String -> Cmd Msg
-sendResult result =
-    sendResult_ <|
-        case result of
-            Ok value ->
-                { isError = False, value = value }
-
-            Err error ->
-                { isError = True, value = error }
-
-
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -107,7 +88,7 @@ update msg model =
 
                         returnResult : Cmd Msg
                         returnResult =
-                            Ok bodyText |> sendResult
+                            Ok bodyText |> Ports.sendResult
                     in
                     returnResult :: cancellations |> Cmd.batch
 
@@ -116,7 +97,7 @@ update msg model =
                         Cmd.none
 
                     else
-                        Err "all requests completed without a single success response" |> sendResult
+                        Err "all requests completed without a single success response" |> Ports.sendResult
             )
 
         Perform cmd ->

--- a/elm-worker/src/EasyRacer/Scenario8.elm
+++ b/elm-worker/src/EasyRacer/Scenario8.elm
@@ -1,18 +1,10 @@
-port module EasyRacer.Scenario8 exposing (main)
+module EasyRacer.Scenario8 exposing (main)
 
+import EasyRacer.Ports as Ports
 import Http
 import Platform exposing (Program)
 import Set exposing (Set)
 import Task
-
-
-type alias ScenarioResult =
-    { isError : Bool
-    , value : String
-    }
-
-
-port sendResult_ : ScenarioResult -> Cmd msg
 
 
 type alias Flags =
@@ -63,17 +55,6 @@ init baseUrl =
     )
 
 
-sendResult : Result String String -> Cmd Msg
-sendResult result =
-    sendResult_ <|
-        case result of
-            Ok value ->
-                { isError = False, value = value }
-
-            Err error ->
-                { isError = True, value = error }
-
-
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -120,7 +101,7 @@ update msg model =
 
               else
                 Result.fromMaybe "all requests completed without a single success response" model.result
-                    |> sendResult
+                    |> Ports.sendResult
             )
 
 

--- a/elm-worker/src/EasyRacer/Scenario9.elm
+++ b/elm-worker/src/EasyRacer/Scenario9.elm
@@ -1,17 +1,9 @@
-port module EasyRacer.Scenario9 exposing (main)
+module EasyRacer.Scenario9 exposing (main)
 
+import EasyRacer.Ports as Ports
 import Http
 import Platform exposing (Program)
 import Set exposing (Set)
-
-
-type alias ScenarioResult =
-    { isError : Bool
-    , value : String
-    }
-
-
-port sendResult_ : ScenarioResult -> Cmd msg
 
 
 type alias Flags =
@@ -59,17 +51,6 @@ init baseUrl =
     )
 
 
-sendResult : Result String String -> Cmd Msg
-sendResult result =
-    sendResult_ <|
-        case result of
-            Ok value ->
-                { isError = False, value = value }
-
-            Err error ->
-                { isError = True, value = error }
-
-
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -91,7 +72,7 @@ update msg model =
                 Cmd.none
 
               else
-                Ok result |> sendResult
+                Ok result |> Ports.sendResult
             )
 
 


### PR DESCRIPTION
Looking at the Elm scenario logic, I see that some of the functions were just there for JS interop (e.g., `sendResult`). Extract those into its own module, so that it's a little less noisy.