### PR TITLE
Fix Easy Racer .NET tests (fix async/await)

### DIFF
--- a/dotnet/EasyRacer.Tests/LibraryTests.cs
+++ b/dotnet/EasyRacer.Tests/LibraryTests.cs
@@ -15,69 +15,69 @@ public class LibraryTests : IClassFixture<TestcontainersFixture>
     public async Task TestScenario1()
     {
         var lib = new Library(fixture.HttpClient);
-        Assert.Equal("right", await lib.Scenario1(fixture.Port));
+        Assert.Equal("right", await lib.Scenario1(fixture.Host, fixture.Port));
     }
 
     [Fact]
     public async Task TestScenario2()
     {
         var lib = new Library(fixture.HttpClient);
-        Assert.Equal("right", await lib.Scenario2(fixture.Port));
+        Assert.Equal("right", await lib.Scenario2(fixture.Host, fixture.Port));
     }
 
     [Fact]
     public async Task TestScenario3()
     {
         var lib = new Library(fixture.HttpClient);
-        Assert.Equal("right", await lib.Scenario3(fixture.Port));
+        Assert.Equal("right", await lib.Scenario3(fixture.Host, fixture.Port));
     }
 
     [Fact]
     public async Task TestScenario4()
     {
         var lib = new Library(fixture.HttpClient);
-        Assert.Equal("right", await lib.Scenario4(fixture.Port));
+        Assert.Equal("right", await lib.Scenario4(fixture.Host, fixture.Port));
     }
 
     [Fact]
     public async Task TestScenario5()
     {
         var lib = new Library(fixture.HttpClient);
-        Assert.Equal("right", await lib.Scenario5(fixture.Port));
+        Assert.Equal("right", await lib.Scenario5(fixture.Host, fixture.Port));
     }
 
     [Fact]
     public async Task TestScenario6()
     {
         var lib = new Library(fixture.HttpClient);
-        Assert.Equal("right", await lib.Scenario6(fixture.Port));
+        Assert.Equal("right", await lib.Scenario6(fixture.Host, fixture.Port));
     }
 
     [Fact]
     public async Task TestScenario7()
     {
         var lib = new Library(fixture.HttpClient);
-        Assert.Equal("right", await lib.Scenario7(fixture.Port));
+        Assert.Equal("right", await lib.Scenario7(fixture.Host, fixture.Port));
     }
 
     [Fact]
     public async Task TestScenario8()
     {
         var lib = new Library(fixture.HttpClient);
-        Assert.Equal("right", await lib.Scenario8(fixture.Port));
+        Assert.Equal("right", await lib.Scenario8(fixture.Host, fixture.Port));
     }
 
     [Fact]
     public async Task TestScenario9()
     {
         var lib = new Library(fixture.HttpClient);
-        Assert.Equal("right", await lib.Scenario9(fixture.Port));
+        Assert.Equal("right", await lib.Scenario9(fixture.Host, fixture.Port));
     }
 
     [Fact]
     public async Task TestScenario10()
     {
         var lib = new Library(fixture.HttpClient);
-        Assert.Equal("right", await lib.Scenario10(fixture.Port));
+        Assert.Equal("right", await lib.Scenario10(fixture.Host, fixture.Port));
     }
 }

--- a/dotnet/EasyRacer.Tests/LibraryTests.cs
+++ b/dotnet/EasyRacer.Tests/LibraryTests.cs
@@ -12,72 +12,72 @@ public class LibraryTests : IClassFixture<TestcontainersFixture>
     }
 
     [Fact]
-    public async void TestScenario1()
+    public async Task TestScenario1()
     {
-        var lib = new Library(fixture.HttpClient);  
+        var lib = new Library(fixture.HttpClient);
         Assert.Equal("right", await lib.Scenario1(fixture.Port));
     }
-    
+
     [Fact]
-    public async void TestScenario2()
+    public async Task TestScenario2()
     {
-        var lib = new Library(fixture.HttpClient);  
+        var lib = new Library(fixture.HttpClient);
         Assert.Equal("right", await lib.Scenario2(fixture.Port));
     }
 
     [Fact]
-    public async void TestScenario3()
+    public async Task TestScenario3()
     {
-        var lib = new Library(fixture.HttpClient);  
+        var lib = new Library(fixture.HttpClient);
         Assert.Equal("right", await lib.Scenario3(fixture.Port));
     }
 
     [Fact]
-    public async void TestScenario4()
+    public async Task TestScenario4()
     {
-        var lib = new Library(fixture.HttpClient);  
+        var lib = new Library(fixture.HttpClient);
         Assert.Equal("right", await lib.Scenario4(fixture.Port));
     }
 
     [Fact]
-    public async void TestScenario5()
+    public async Task TestScenario5()
     {
-        var lib = new Library(fixture.HttpClient);  
+        var lib = new Library(fixture.HttpClient);
         Assert.Equal("right", await lib.Scenario5(fixture.Port));
     }
 
     [Fact]
-    public async void TestScenario6()
+    public async Task TestScenario6()
     {
-        var lib = new Library(fixture.HttpClient);  
+        var lib = new Library(fixture.HttpClient);
         Assert.Equal("right", await lib.Scenario6(fixture.Port));
     }
 
     [Fact]
-    public async void TestScenario7()
+    public async Task TestScenario7()
     {
-        var lib = new Library(fixture.HttpClient);  
+        var lib = new Library(fixture.HttpClient);
         Assert.Equal("right", await lib.Scenario7(fixture.Port));
     }
 
     [Fact]
-    public async void TestScenario8()
+    public async Task TestScenario8()
     {
-        var lib = new Library(fixture.HttpClient);  
+        var lib = new Library(fixture.HttpClient);
         Assert.Equal("right", await lib.Scenario8(fixture.Port));
     }
 
     [Fact]
-    public async void TestScenario9()
+    public async Task TestScenario9()
     {
-        var lib = new Library(fixture.HttpClient);  
+        var lib = new Library(fixture.HttpClient);
         Assert.Equal("right", await lib.Scenario9(fixture.Port));
     }
 
     [Fact]
-    public async void TestScenario10()
+    public async Task TestScenario10()
     {
-        var lib = new Library(fixture.HttpClient);  
+        var lib = new Library(fixture.HttpClient);
         Assert.Equal("right", await lib.Scenario10(fixture.Port));
     }
 }

--- a/dotnet/EasyRacer.Tests/TestcontainersFixture.cs
+++ b/dotnet/EasyRacer.Tests/TestcontainersFixture.cs
@@ -16,6 +16,8 @@ public sealed class TestcontainersFixture : IAsyncLifetime, IDisposable
 
     public HttpClient HttpClient { get; } = new HttpClient();
 
+    public string Host => container.Hostname;
+
     public ushort Port => container.GetMappedPublicPort(HttpPort);
 
     public Task InitializeAsync()
@@ -25,7 +27,7 @@ public sealed class TestcontainersFixture : IAsyncLifetime, IDisposable
 
     public Task DisposeAsync()
     {
-        return container.StopAsync();
+        return container.DisposeAsync().AsTask();
     }
 
     public void Dispose()

--- a/dotnet/EasyRacer.sln
+++ b/dotnet/EasyRacer.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyRacer", "EasyRacer\EasyRacer.csproj", "{52873FC2-AF8B-43F9-9F85-B9BDEFC9B126}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyRacer.Tests", "EasyRacer.Tests\EasyRacer.Tests.csproj", "{65168772-B239-4C18-9E18-67F33A6906F8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{52873FC2-AF8B-43F9-9F85-B9BDEFC9B126}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52873FC2-AF8B-43F9-9F85-B9BDEFC9B126}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52873FC2-AF8B-43F9-9F85-B9BDEFC9B126}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52873FC2-AF8B-43F9-9F85-B9BDEFC9B126}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65168772-B239-4C18-9E18-67F33A6906F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65168772-B239-4C18-9E18-67F33A6906F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65168772-B239-4C18-9E18-67F33A6906F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65168772-B239-4C18-9E18-67F33A6906F8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/dotnet/EasyRacer/Library.cs
+++ b/dotnet/EasyRacer/Library.cs
@@ -1,7 +1,9 @@
+using System.Text;
+
 namespace EasyRacer;
 
 /// <summary>
-/// Implements 10 scenarios demonstrating structred concurrency in .NET.
+/// Implements 10 scenarios demonstrating structured concurrency in .NET.
 /// </summary>
 public class Library(HttpClient http)
 {
@@ -9,18 +11,20 @@ public class Library(HttpClient http)
     /// Race 2 concurrent requests, print the result of the first one to return
     /// and cancels the other one.
     /// </summary>
-    public async Task<string> Scenario1(int port)
+    public async Task<string> Scenario1(string host, ushort port)
     {
-        var cancel = new CancellationTokenSource();
+        using var cancel = new CancellationTokenSource();
 
-        var req1 = http.GetStringAsync(GetUrl(port, 1), cancel.Token);
-        var req2 = http.GetStringAsync(GetUrl(port, 1), cancel.Token);
+        var url = GetUrl(host, port, 1);
 
-        var result = await Task.WhenAny(req1, req2).ContinueWith(result =>
-        {
-            cancel.Cancel();
-            return result.Result;
-        });
+        var req1 = http.GetStringAsync(url, cancel.Token);
+        var req2 = http.GetStringAsync(url, cancel.Token);
+
+        var result = await Task.WhenAny(req1, req2)
+            .ConfigureAwait(false);
+
+        await cancel.CancelAsync()
+            .ConfigureAwait(false);
 
         return await result;
     }
@@ -28,103 +32,119 @@ public class Library(HttpClient http)
     /// <summary>
     /// Race 2 concurrent requests, where one produces a connection error.
     /// </summary>
-    public async Task<string> Scenario2(int port)
+    public async Task<string> Scenario2(string host, ushort port)
     {
+        using var cancel = new CancellationTokenSource();
+
+        var url = GetUrl(host, port, 2);
+
         var tasks = new List<Task<HttpResponseMessage>>
         {
-            http.GetAsync(GetUrl(port, 2)),
-            http.GetAsync(GetUrl(port, 2))
+            http.GetAsync(url, cancel.Token),
+            http.GetAsync(url, cancel.Token)
         };
 
-        return await RaceStringResultAsync(tasks);
+        return await RaceStringResultAsync(tasks, cancel)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
     /// Race 10000 concurrent requests, accept the first that succeeds.
     /// </summary>
-    public async Task<string> Scenario3(int port)
+    public async Task<string> Scenario3(string host, ushort port)
     {
-        const int requestCount = 10000;
-        var url = GetUrl(port, 3);
-
         using var cancel = new CancellationTokenSource();
 
-        var tasks = new List<Task<HttpResponseMessage>>(requestCount);
+        var url = GetUrl(host, port, 3);
 
-        for (var i = 0; i < requestCount; i++)
-        {
-            tasks.Add(http.GetAsync(url, cancel.Token));
-        }
+        var tasks = Enumerable.Range(0, 10000)
+            .Select(_ => http.GetAsync(url, cancel.Token))
+            .ToList();
 
-        return await RaceStringResultAsync(tasks, cancel);
+        return await RaceStringResultAsync(tasks, cancel)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
     /// Race 2 requests, 1 with a 1 second timeout.
     /// </summary>
-    public async Task<string> Scenario4(int port)
+    public async Task<string> Scenario4(string host, ushort port)
     {
-        var timeout = TimeSpan.FromSeconds(1);
-        using var cancel = new CancellationTokenSource(timeout);
+        using var cancel = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+
+        var url = GetUrl(host, port, 4);
 
         var tasks = new List<Task<HttpResponseMessage>>
         {
-            http.GetAsync(GetUrl(port, 4), cancel.Token),
-            http.GetAsync(GetUrl(port, 4), default(CancellationToken))
+            http.GetAsync(url, timeout.Token),
+            http.GetAsync(url, default(CancellationToken))
         };
 
-        return await RaceStringResultAsync(tasks);
+        return await RaceStringResultAsync(tasks, cancel)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
     /// Race 2 concurrent requests where a non-200 response is a loser
     /// </summary>
-    public async Task<string> Scenario5(int port)
+    public async Task<string> Scenario5(string host, ushort port)
     {
         using var cancel = new CancellationTokenSource();
 
+        var url = GetUrl(host, port, 5);
+
         var tasks = new List<Task<HttpResponseMessage>>
         {
-            http.GetAsync(GetUrl(port, 5), cancel.Token),
-            http.GetAsync(GetUrl(port, 5), cancel.Token)
+            http.GetAsync(url, cancel.Token),
+            http.GetAsync(url, cancel.Token)
         };
 
-        return await RaceStringResultAsync(tasks, cancel);
+        return await RaceStringResultAsync(tasks, cancel)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
     /// Race 3 concurrent requests where a non-200 response is a loser
     /// </summary>
-    public async Task<string> Scenario6(int port)
+    public async Task<string> Scenario6(string host, ushort port)
     {
         // Set a long timeout, just in case 1 or more never complete.
         using var cancel = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
+        var url = GetUrl(host, port, 6);
+
         var tasks = new List<Task<HttpResponseMessage>>
         {
-            http.GetAsync(GetUrl(port, 6), cancel.Token),
-            http.GetAsync(GetUrl(port, 6), cancel.Token),
-            http.GetAsync(GetUrl(port, 6), cancel.Token)
+            http.GetAsync(url, cancel.Token),
+            http.GetAsync(url, cancel.Token),
+            http.GetAsync(url, cancel.Token)
         };
 
-        return await RaceStringResultAsync(tasks, cancel);
+        return await RaceStringResultAsync(tasks, cancel)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
     /// Start a request, wait at least 3 seconds then start a second request (hedging)
     /// </summary>
-    public async Task<string> Scenario7(int port)
+    public async Task<string> Scenario7(string host, ushort port)
     {
-        var cancel = new CancellationTokenSource();
+        using var cancel = new CancellationTokenSource();
 
-        var tasks = new List<Task<HttpResponseMessage>>
-        {
-            http.GetAsync(GetUrl(port, 7), cancel.Token),
-            await Task.Delay(TimeSpan.FromSeconds(3))
-                .ContinueWith(_ => http.GetAsync(GetUrl(port, 7), cancel.Token)),
-        };
+        var url = GetUrl(host, port, 7);
 
-        return await RaceStringResultAsync(tasks, cancel);
+        var tasks = new List<Task<HttpResponseMessage>>();
+        tasks.Add(http.GetAsync(url, cancel.Token));
+
+        await Task.Delay(TimeSpan.FromSeconds(3), default(CancellationToken))
+            .ConfigureAwait(false);
+
+        tasks.Add(http.GetAsync(url, cancel.Token));
+
+        return await RaceStringResultAsync(tasks, cancel)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -132,106 +152,124 @@ public class Library(HttpClient http)
     /// released through other requests. The "use" request can return a non-20x
     /// request, in which case it is not a winner.
     /// </summary>
-    public async Task<string> Scenario8(int port)
+    public async Task<string> Scenario8(string host, ushort port)
     {
         using var cancel = new CancellationTokenSource();
 
         var tasks = new List<Task<HttpResponseMessage>>
         {
-            CreateScenario8Request(port, cancel.Token),
-            CreateScenario8Request(port, cancel.Token)
+            CreateScenario8Request(host, port, cancel.Token),
+            CreateScenario8Request(host, port, cancel.Token)
         };
 
-        return await RaceStringResultAsync(tasks, cancel);
+        return await RaceStringResultAsync(tasks, cancel)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
     /// Wraps Scenario 8's 3 phases; Open, Use, Close.
     /// </summary>
-    private async Task<HttpResponseMessage> CreateScenario8Request(int port,
+    private async Task<HttpResponseMessage> CreateScenario8Request(
+        string host,
+        ushort port,
         CancellationToken cancel)
     {
-        var baseUrl = GetUrl(port, 8);
+        var baseUrl = GetUrl(host, port, 8);
         var openUrl = baseUrl + "?open";
         string UseUrl(string id) => baseUrl + $"?use={id}";
         string CloseUrl(string id) => baseUrl + $"?close={id}";
 
-        var id = await http.GetStringAsync(openUrl);
+        var id = await http.GetStringAsync(openUrl, cancel)
+            .ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(id))
+        {
             throw new ApplicationException("No id returned");
+        }
 
         try
         {
-            return await http.GetAsync(UseUrl(id), cancel);
+            return await http.GetAsync(UseUrl(id), cancel)
+                .ConfigureAwait(false);
         }
         finally
         {
-            await http.GetAsync(CloseUrl(id));
+            await http.GetAsync(CloseUrl(id), cancel)
+                .ConfigureAwait(false);
         }
     }
 
     /// <summary>
     /// Make 10 concurrent requests where 5 return a 200 response with a letter
     /// </summary>
-    public async Task<string> Scenario9(int port)
+    public async Task<string> Scenario9(string host, ushort port)
     {
-        var cancel = new CancellationTokenSource();
+        using var cancel = new CancellationTokenSource();
 
-        var tasks = new List<Task>();
+        var url = GetUrl(host, port, 9);
 
-        string answer = string.Empty;
+        var answer = new StringBuilder();
 
-        for (int i = 0; i < 10; i++)
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => http.GetStringAsync(url, cancel.Token))
+            .Select(response => response.ContinueWith(task =>
+            {
+                answer.Append(task.Result);
+
+                if (5.Equals(answer.Length))
+                {
+                    cancel.Cancel();
+                }
+            }, cancel.Token))
+            .ToList();
+
+        try
         {
-            tasks.Add(
-                http.GetStringAsync(GetUrl(port, 9), cancel.Token)
-                    .ContinueWith(task =>
-                    {
-                        answer += task.Result;
-
-                        if (answer.Length == 5)
-                            cancel.Cancel();
-                    })
-            );
+            await Task.WhenAll(tasks)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            /* Ignore */
         }
 
-        try { await Task.WhenAll(tasks); }
-        catch ( Exception ) { /*Ignore*/ }
-
-        return answer;
+        return answer.ToString();
     }
 
     /// <summary>
     /// This scenario validates that a computationally heavy task can be run in
     /// parallel to another task, and then cancelled.
     /// </summary>
-    public async Task<string> Scenario10(int port)
+    public async Task<string> Scenario10(string host, ushort port)
     {
         var scenario = new Scenario10(http);
-        return await scenario.Run(GetUrl(port, 10));
+        return await scenario.Run(GetUrl(host, port, 10))
+            .ConfigureAwait(false);
     }
 
     /// <summary>
     /// Helper method to return the first successful http request result.
     /// Waits for the first successful task and cancels all others.
     /// </summary>
-    private async Task<string> RaceStringResultAsync(
+    private static async Task<string> RaceStringResultAsync(
         List<Task<HttpResponseMessage>> tasks,
-        CancellationTokenSource? cancel = null)
+        CancellationTokenSource cancel)
     {
-        // If no cancel token is provided, create one with a reasonable timeout.
-        if (cancel == null)
-            cancel = new CancellationTokenSource(TimeSpan.FromSeconds(100));
-
         while (!cancel.IsCancellationRequested && tasks.Count > 0)
         {
-            var task = await Task.WhenAny(tasks);
+            var task = await Task.WhenAny(tasks)
+                .ConfigureAwait(false);
 
             if (task.IsCompletedSuccessfully && task.Result.IsSuccessStatusCode)
             {
-                cancel.Cancel();
-                return await task.Result.Content.ReadAsStringAsync();
+                await cancel.CancelAsync()
+                    .ConfigureAwait(false);
+
+                var response = await task
+                    .ConfigureAwait(false);
+
+                return await response.Content.ReadAsStringAsync()
+                    .ConfigureAwait(false);
             }
 
             // Task wasn't a success, so don't wait on this task any more.
@@ -244,5 +282,5 @@ public class Library(HttpClient http)
     /// <summary>
     /// Helper method to get the url for a scenario.
     /// </summary>
-    private string GetUrl(int port, int scenario) => $"http://127.0.0.1:{port}/{scenario}";
+    private static string GetUrl(string host, ushort port, int scenario) => $"http://{host}:{port}/{scenario}";
 }

--- a/dotnet/EasyRacer/Library.cs
+++ b/dotnet/EasyRacer/Library.cs
@@ -20,13 +20,13 @@ public class Library(HttpClient http)
         var req1 = http.GetStringAsync(url, cancel.Token);
         var req2 = http.GetStringAsync(url, cancel.Token);
 
-        var result = await Task.WhenAny(req1, req2)
+        var task = await Task.WhenAny(req1, req2)
             .ConfigureAwait(false);
 
         await cancel.CancelAsync()
             .ConfigureAwait(false);
 
-        return await result;
+        return task.Result;
     }
 
     /// <summary>
@@ -265,8 +265,7 @@ public class Library(HttpClient http)
                 await cancel.CancelAsync()
                     .ConfigureAwait(false);
 
-                var response = await task
-                    .ConfigureAwait(false);
+                using var response = task.Result;
 
                 return await response.Content.ReadAsStringAsync()
                     .ConfigureAwait(false);

--- a/dotnet/EasyRacer/Library.cs
+++ b/dotnet/EasyRacer/Library.cs
@@ -6,7 +6,7 @@ namespace EasyRacer;
 public class Library(HttpClient http)
 {
     /// <summary>
-    /// Race 2 concurrent requests, print the result of the first one to return 
+    /// Race 2 concurrent requests, print the result of the first one to return
     /// and cancels the other one.
     /// </summary>
     public async Task<string> Scenario1(int port)
@@ -16,10 +16,9 @@ public class Library(HttpClient http)
         var req1 = http.GetStringAsync(GetUrl(port, 1), cancel.Token);
         var req2 = http.GetStringAsync(GetUrl(port, 1), cancel.Token);
 
-        var result = await Task.WhenAny(req1, req2).ContinueWith(result => 
+        var result = await Task.WhenAny(req1, req2).ContinueWith(result =>
         {
             cancel.Cancel();
-
             return result.Result;
         });
 
@@ -39,20 +38,20 @@ public class Library(HttpClient http)
 
         return await RaceStringResultAsync(tasks);
     }
-    
+
     /// <summary>
     /// Race 10000 concurrent requests, accept the first that succeeds.
     /// </summary>
     public async Task<string> Scenario3(int port)
     {
-        const int RequestCount = 10000;
+        const int requestCount = 10000;
         var url = GetUrl(port, 3);
 
         using var cancel = new CancellationTokenSource();
 
-        var tasks = new List<Task<HttpResponseMessage>>(RequestCount);
+        var tasks = new List<Task<HttpResponseMessage>>(requestCount);
 
-        for (int i = 0; i < RequestCount; i++)
+        for (var i = 0; i < requestCount; i++)
         {
             tasks.Add(http.GetAsync(url, cancel.Token));
         }
@@ -71,12 +70,11 @@ public class Library(HttpClient http)
         var tasks = new List<Task<HttpResponseMessage>>
         {
             http.GetAsync(GetUrl(port, 4), cancel.Token),
-            http.GetAsync(GetUrl(port, 4))
+            http.GetAsync(GetUrl(port, 4), default(CancellationToken))
         };
 
         return await RaceStringResultAsync(tasks);
     }
-
 
     /// <summary>
     /// Race 2 concurrent requests where a non-200 response is a loser
@@ -130,15 +128,15 @@ public class Library(HttpClient http)
     }
 
     /// <summary>
-    /// Race 2 concurrent requests that "use" a resource which is obtained and 
-    /// released through other requests. The "use" request can return a non-20x 
+    /// Race 2 concurrent requests that "use" a resource which is obtained and
+    /// released through other requests. The "use" request can return a non-20x
     /// request, in which case it is not a winner.
     /// </summary>
     public async Task<string> Scenario8(int port)
     {
-        var cancel = new CancellationTokenSource();
+        using var cancel = new CancellationTokenSource();
 
-        var tasks = new List<Task<HttpResponseMessage>> 
+        var tasks = new List<Task<HttpResponseMessage>>
         {
             CreateScenario8Request(port, cancel.Token),
             CreateScenario8Request(port, cancel.Token)
@@ -150,7 +148,7 @@ public class Library(HttpClient http)
     /// <summary>
     /// Wraps Scenario 8's 3 phases; Open, Use, Close.
     /// </summary>
-    private async Task<HttpResponseMessage> CreateScenario8Request(int port, 
+    private async Task<HttpResponseMessage> CreateScenario8Request(int port,
         CancellationToken cancel)
     {
         var baseUrl = GetUrl(port, 8);
@@ -171,7 +169,7 @@ public class Library(HttpClient http)
         {
             await http.GetAsync(CloseUrl(id));
         }
-    }    
+    }
 
     /// <summary>
     /// Make 10 concurrent requests where 5 return a 200 response with a letter
@@ -188,7 +186,7 @@ public class Library(HttpClient http)
         {
             tasks.Add(
                 http.GetStringAsync(GetUrl(port, 9), cancel.Token)
-                    .ContinueWith(task => 
+                    .ContinueWith(task =>
                     {
                         answer += task.Result;
 
@@ -216,10 +214,10 @@ public class Library(HttpClient http)
 
     /// <summary>
     /// Helper method to return the first successful http request result.
-    /// Waits for the first successful task and cancels all others. 
+    /// Waits for the first successful task and cancels all others.
     /// </summary>
     private async Task<string> RaceStringResultAsync(
-        List<Task<HttpResponseMessage>> tasks, 
+        List<Task<HttpResponseMessage>> tasks,
         CancellationTokenSource? cancel = null)
     {
         // If no cancel token is provided, create one with a reasonable timeout.
@@ -236,15 +234,15 @@ public class Library(HttpClient http)
                 return await task.Result.Content.ReadAsStringAsync();
             }
 
-            // Task wasn't a succes, so don't wait on this task any more.
+            // Task wasn't a success, so don't wait on this task any more.
             tasks.Remove(task);
         }
 
         return string.Empty;
-    }    
+    }
 
     /// <summary>
     /// Helper method to get the url for a scenario.
     /// </summary>
-    private string GetUrl(int port, int scenario) => $"http://localhost:{port}/{scenario}";    
+    private string GetUrl(int port, int scenario) => $"http://127.0.0.1:{port}/{scenario}";
 }

--- a/dotnet/EasyRacer/Program.cs
+++ b/dotnet/EasyRacer/Program.cs
@@ -1,17 +1,18 @@
 ﻿using EasyRacer;
 
-const int Port = 8080;
+const string Host = "localhost";
+const ushort Port = 8080;
 
 var http = new HttpClient();
 var lib = new Library(http);
 
-Console.WriteLine(await lib.Scenario1(Port));
-Console.WriteLine(await lib.Scenario2(Port));
-Console.WriteLine(await lib.Scenario3(Port));
-Console.WriteLine(await lib.Scenario4(Port));
-Console.WriteLine(await lib.Scenario5(Port));
-Console.WriteLine(await lib.Scenario6(Port));
-Console.WriteLine(await lib.Scenario7(Port));
-Console.WriteLine(await lib.Scenario8(Port));
-Console.WriteLine(await lib.Scenario9(Port));
-Console.WriteLine(await lib.Scenario10(Port));
+Console.WriteLine(await lib.Scenario1(Host, Port));
+Console.WriteLine(await lib.Scenario2(Host, Port));
+Console.WriteLine(await lib.Scenario3(Host, Port));
+Console.WriteLine(await lib.Scenario4(Host, Port));
+Console.WriteLine(await lib.Scenario5(Host, Port));
+Console.WriteLine(await lib.Scenario6(Host, Port));
+Console.WriteLine(await lib.Scenario7(Host, Port));
+Console.WriteLine(await lib.Scenario8(Host, Port));
+Console.WriteLine(await lib.Scenario9(Host, Port));
+Console.WriteLine(await lib.Scenario10(Host, Port));

--- a/dotnet/EasyRacer/Scenario10.cs
+++ b/dotnet/EasyRacer/Scenario10.cs
@@ -50,7 +50,7 @@ public class Scenario10(HttpClient http)
     {
         while (true)
         {
-            await Task.Delay(TimeSpan.FromSeconds(0.1));
+            await Task.Delay(TimeSpan.FromSeconds(1));
 
             var loadUrl = $"{url}?{Id}={cpuUsage.ToString(CultureInfo.InvariantCulture)}";
             var response = await http.GetAsync(loadUrl);


### PR DESCRIPTION
Hi 👋, I came across this project and noticed some issues/flaws in the .NET implementation. After investigating, I propose the following changes:

1. The usage of `async void` is generally not recommended (except for events). I couldn't find a reason why the tests should use this method signature; using `async Task` is the preferred approach and is recommended.
2. Synchronously waiting on an asynchronous operation (sync over async) is also not recommended and should be avoided. It blocks (wastes) one thread, which can lead to thread starvation and deadlocks.
3. It is recommended to let Testcontainers resolve the actual `Hostname`. Depending on the container runtime and environment, the host can differ. Using the static value `localhost` can cause further issues. There is a bug or an issue in Docker Desktop where the IPv4/IPv6 binding does not get the same port assigned. Depending on how the operating system resolves `localhost`, it is necessary to resolve to the correct randomly assigned host port (find further information [here](https://github.com/testcontainers/testcontainers-dotnet/issues/825)).
4. Scenario 10 does not consider the culture when converting the double CPU usage to a string. This breaks the HTTP request because, depending on the user's OS and settings, `0.95d.ToString()` will be `0,95` instead of `0.95`.

Before the changes, I was not able to run the tests. With the mentioned changes, the tests now run fine. However, _TestScenario3_ is still sometimes flaky. Unfortunately, I haven't had the time to take a closer look at it.
