### PR TITLE
More Scala Gears

### DIFF
--- a/scala-gears/src/main/scala/EasyRacerClient.scala
+++ b/scala-gears/src/main/scala/EasyRacerClient.scala
@@ -69,12 +69,12 @@ object EasyRacerClient:
     val url = scenarioUrl(3)
     val reqs = Seq.fill(10000):
       Future(scenarioRequest(url).execute().link().body().string())
-    reqs.awaitFirst
+    reqs.awaitFirstWithCancel
 
   def scenario4(scenarioUrl: Int => String)(using Async.Spawn): String =
     val url = scenarioUrl(4)
     def req = Future(scenarioRequest(url).execute().link().body().string())
-    Seq(withTimeout(1.second)(req), req).awaitFirst
+    Seq(withTimeout(1.second)(req), req).awaitFirstWithCancel
 
   def scenario5(scenarioUrl: Int => String)(using Async.Spawn): String =
     val url = scenarioUrl(5)

--- a/scala-gears/src/main/scala/EasyRacerClient.scala
+++ b/scala-gears/src/main/scala/EasyRacerClient.scala
@@ -53,11 +53,17 @@ object EasyRacerClient:
     Seq(req, req).awaitFirstWithCancel
     // Or:
     // req.orWithCancel(req).await
+    // Or:
+    // Async.race(req, req).await
 
   def scenario2(scenarioUrl: Int => String)(using Async.Spawn): String =
     val url = scenarioUrl(2)
     def req = Future(scenarioRequest(url).execute().link().body().string())
     Seq(req, req).awaitFirstWithCancel
+    // Or:
+    // req.orWithCancel(req).await
+    // Does not work (Async.race returns first to _complete_ - even if it completes with a failure):
+    // Async.race(req, req).await
 
   def scenario3(scenarioUrl: Int => String)(using Async.Spawn): String =
     val url = scenarioUrl(3)

--- a/scala-gears/src/main/scala/EasyRacerClient.scala
+++ b/scala-gears/src/main/scala/EasyRacerClient.scala
@@ -74,12 +74,7 @@ object EasyRacerClient:
   def scenario4(scenarioUrl: Int => String)(using Async.Spawn): String =
     val url = scenarioUrl(4)
     def req = Future(scenarioRequest(url).execute().link().body().string())
-    // Does not work:
-//    Seq(withTimeout(1.second)(req), req).awaitFirst
-    def timeout =
-      AsyncOperations.sleep(1.second)
-      Future.rejected(TimeoutException())
-    Seq(req.orWithCancel(timeout), req).awaitFirst
+    Seq(withTimeout(1.second)(req), req).awaitFirst
 
   def scenario5(scenarioUrl: Int => String)(using Async.Spawn): String =
     val url = scenarioUrl(5)

--- a/scala-gears/src/main/scala/EasyRacerClient.scala
+++ b/scala-gears/src/main/scala/EasyRacerClient.scala
@@ -151,6 +151,13 @@ object EasyRacerClient:
              if !cancelled.get() then digest(messageDigest.digest(bytes))
            digest(Random.nextBytes(512))
       new BlockingCancellable().link().start()
+    // Or:
+    // def blocking = Future:
+    //   @tailrec def digest(bytes: Array[Byte]): Unit =
+    //     // 0-time sleep introduces a suspension point for cancellation
+    //     AsyncOperations.sleep(0.nanosecond)
+    //     digest(messageDigest.digest(bytes))
+    //   digest(Random.nextBytes(512))
 
     def blocker =
       val url = s"${scenarioUrl(10)}?$id"

--- a/scala-gears/src/main/scala/EasyRacerClient.scala
+++ b/scala-gears/src/main/scala/EasyRacerClient.scala
@@ -147,9 +147,9 @@ object EasyRacerClient:
           unlink()
 
         def start(): Unit =
-          var result = Random.nextBytes(512)
-          while (!cancelled.get())
-            result = messageDigest.digest(result)
+           @tailrec def digest(bytes: Array[Byte]): Unit =
+             if !cancelled.get() then digest(messageDigest.digest(bytes))
+           digest(Random.nextBytes(512))
       new BlockingCancellable().link().start()
 
     def blocker =

--- a/scala-gears/src/main/scala/EasyRacerClient.scala
+++ b/scala-gears/src/main/scala/EasyRacerClient.scala
@@ -113,7 +113,7 @@ object EasyRacerClient:
     def reqRes = Future:
       val id = open
       try use(id)
-      finally close(id)
+      finally uninterruptible(close(id))
 
     Seq(reqRes, reqRes).awaitFirstWithCancel
 


### PR DESCRIPTION
1. (Scenarios 1 and 2 - applies to all others as well) Tried using `Async.race`, added notes in comment for where it could work, and where it wouldn't (`Async.race` returns first to _complete_, failing the group if the first to complete is a failure)
2. (Scenario 3 and 4) Use `awaitFirstWithCancel` instead of `awaitFirst`
3. (Scenario 4) `withTimeout(...)` which I swear wasn't working before, seems to be working now, even though all I did was uncomment the original... 🤷
4. (Scenario 8) Made `close()` call `uninterruptible`
5. (Scenario 10) Re-implemented the CPU-bound blocking operation as a `@tailrec` recursive function to avoid use of `var`.
6. (Scenario 10) Provided alternative version of `def blocking` that:
    - Is more succinct as it does not require us to implement a whole custom `Cancellable`
    - But is a bit ugly/hacky in that it adds a call to `AsyncOperations.sleep(0.nanoseconds)` to force the introduction of a suspension point