### PR TITLE
swift-async Testcontainers cloud

### DIFF
--- a/swift-async/Sources/EasyRacer/EasyRacer.swift
+++ b/swift-async/Sources/EasyRacer/EasyRacer.swift
@@ -24,7 +24,7 @@ extension URLSession {
 @main
 public struct EasyRacer {
     let baseURL: URL
-    let urlSession: URLSession = ScalableURLSession(
+    let urlSession: some URLSession = ScalableURLSession(
         configuration: {
             let configuration = URLSessionConfiguration.ephemeral
             configuration.httpMaximumConnectionsPerHost = 1_000

--- a/swift-async/Sources/EasyRacer/EasyRacer.swift
+++ b/swift-async/Sources/EasyRacer/EasyRacer.swift
@@ -32,7 +32,7 @@ public struct EasyRacer {
             return configuration
         }(),
         requestsPerSession: 100,
-        timeIntervalBetweenRequests: 0.05 // 50ms
+        timeIntervalBetweenRequests: 0.005 // 5ms
     )
 
     func scenario1() async -> String? {

--- a/swift-async/Sources/EasyRacer/URLSession.swift
+++ b/swift-async/Sources/EasyRacer/URLSession.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// URLSession operations we actually use in Easy Racer
+protocol URLSession {
+    func data(from url: URL) async throws -> (Data, URLResponse)
+}
+
+/// Make sure the URLSession protocol isn't defining incompatible methods
+extension Foundation.URLSession: URLSession {
+}
+
+/// URLSession implementation that is able to handle 10k concurrent connections
+///
+///  It does this by delegating to Foundation.URLSession, ensuring:
+///   - Each delegatee handles no more than requestsPerSession requests
+///   - Requests are at least timeIntervalBetweenRequests apart
+///     (Needed in some environments, e.g., GitHub Actions)
+actor ScalableURLSession: URLSession {
+    private static let nanosecondsPerSecond: UInt64 = 1_000_000_000
+    
+    private let configuration: URLSessionConfiguration
+    private let requestsPerSession: UInt
+    private let timeIntervalBetweenRequests: TimeInterval
+    
+    private var currentDelegatee: Foundation.URLSession
+    private var currentRequestCount: UInt = 0
+    private var nextRequestNotBefore: Date = .distantPast
+    private var delegatee: Foundation.URLSession {
+        get {
+            if currentRequestCount < requestsPerSession {
+                currentRequestCount += 1
+                return currentDelegatee
+            } else {
+                currentDelegatee.finishTasksAndInvalidate()
+                currentDelegatee = Foundation.URLSession(configuration: configuration)
+                currentRequestCount = 0
+
+                return currentDelegatee
+            }
+        }
+    }
+    
+    init(
+        configuration: URLSessionConfiguration,
+        requestsPerSession: UInt = 100,
+        timeIntervalBetweenRequests: TimeInterval = 0.001
+    ) {
+        self.configuration = configuration
+        self.requestsPerSession = requestsPerSession
+        self.timeIntervalBetweenRequests = timeIntervalBetweenRequests
+        self.currentDelegatee = Foundation.URLSession(configuration: configuration)
+    }
+    
+    func data(from url: URL) async throws -> (Data, URLResponse) {
+        defer {
+            nextRequestNotBefore = Date()
+                .addingTimeInterval(timeIntervalBetweenRequests)
+        }
+        let delay: TimeInterval = nextRequestNotBefore.timeIntervalSinceNow
+        if delay > 0 {
+            try await Task.sleep(nanoseconds: UInt64(delay) * Self.nanosecondsPerSecond)
+        }
+        
+        return try await delegatee.data(from: url)
+    }
+}


### PR DESCRIPTION
OK, finally, a swift-async solution that is reliable on GitHub Actions with Testcontainers cloud.

Some notes:
- Introduced what I'm calling `ScalableURLSession` that is meant to be a drop in replacement for Apple's `URLSession`, but is able to handle 10k connections reliably on GitHub Actions.
- Removed code related to URLSession stability from `EasyRacer.swift`, making the racing logic easier to follow.