### PR TITLE
swift-async Testcontainers cloud

### DIFF
--- a/swift-async/Sources/EasyRacer/EasyRacer.swift
+++ b/swift-async/Sources/EasyRacer/EasyRacer.swift
@@ -24,10 +24,19 @@ extension URLSession {
 @main
 public struct EasyRacer {
     let baseURL: URL
-    
+    let urlSession: some URLSession = ScalableURLSession(
+        configuration: {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.httpMaximumConnectionsPerHost = 1_000
+            configuration.timeoutIntervalForRequest = 120
+            return configuration
+        }(),
+        requestsPerSession: 100,
+        timeIntervalBetweenRequests: 0.005 // 5ms
+    )
+
     func scenario1() async -> String? {
         let url: URL = baseURL.appendingPathComponent("1")
-        let urlSession: URLSession = URLSession(configuration: .ephemeral)
         
         let result: String? = await withTaskGroup(of: String?.self) { group in
             defer { group.cancelAll() }
@@ -43,7 +52,6 @@ public struct EasyRacer {
     
     func scenario2() async -> String? {
         let url: URL = baseURL.appendingPathComponent("2")
-        let urlSession: URLSession = URLSession(configuration: .ephemeral)
         
         let result: String? = await withTaskGroup(of: String?.self) { group in
             defer { group.cancelAll() }
@@ -59,32 +67,13 @@ public struct EasyRacer {
     
     func scenario3() async -> String? {
         let url: URL = baseURL.appendingPathComponent("3")
-        // Ideally, we'd use a single URLSession configured to handle 10k connections.
-        // This doesn't seem to work - observed from the scenario server, it'll create
-        // ~110 connections, and then stall.
-        // URLSession is close-sourced, so it's hard to tell what is going on.
-//        let urlSession: URLSession = URLSession(
-//            configuration: {
-//                let urlSessionCfg = URLSessionConfiguration.ephemeral
-//                urlSessionCfg.httpMaximumConnectionsPerHost = 10_000
-//                return urlSessionCfg
-//            }(),
-//            delegate: nil,
-//            delegateQueue: {
-//                let opQueue: OperationQueue = OperationQueue()
-//                opQueue.maxConcurrentOperationCount = 10_000
-//                return opQueue
-//            }()
-//        )
-        let urlSessionCfg = URLSessionConfiguration.ephemeral
-        urlSessionCfg.timeoutIntervalForRequest = 900 // Seems to be required for GitHub Action environment
         
         let result: String? = await withTaskGroup(of: String?.self) { group in
             defer { group.cancelAll() }
             
             for _ in 1...10_000 {
                 group.addTask {
-                    try? await URLSession(configuration: urlSessionCfg).bodyText(from: url)
+                    return try? await urlSession.bodyText(from: url)
                 }
             }
             
@@ -96,8 +85,7 @@ public struct EasyRacer {
     
     func scenario4() async -> String? {
         let url: URL = baseURL.appendingPathComponent("4")
-        let urlSession: URLSession = URLSession(configuration: .ephemeral)
-        let urlSession1SecTimeout: URLSession = URLSession(configuration: {
+        let urlSession1SecTimeout: URLSession = Foundation.URLSession(configuration: {
             let configuration: URLSessionConfiguration = .ephemeral
             configuration.timeoutIntervalForRequest = 1
             return configuration
@@ -117,7 +105,6 @@ public struct EasyRacer {
     
     func scenario5() async -> String? {
         let url: URL = baseURL.appendingPathComponent("5")
-        let urlSession: URLSession = URLSession(configuration: .ephemeral)
         
         let result: String? = await withTaskGroup(of: String?.self) { group in
             defer { group.cancelAll() }
@@ -133,7 +120,6 @@ public struct EasyRacer {
     
     func scenario6() async -> String? {
         let url: URL = baseURL.appendingPathComponent("6")
-        let urlSession: URLSession = URLSession(configuration: .ephemeral)
         
         let result: String? = await withTaskGroup(of: String?.self) { group in
             defer { group.cancelAll() }
@@ -150,7 +136,6 @@ public struct EasyRacer {
     
     func scenario7() async -> String? {
         let url: URL = baseURL.appendingPathComponent("7")
-        let urlSession: URLSession = URLSession(configuration: .ephemeral)
         
         let result: String? = await withTaskGroup(of: String?.self) { group in
             defer { group.cancelAll() }
@@ -169,7 +154,6 @@ public struct EasyRacer {
     
     func scenario8() async -> String? {
         let url: URL = baseURL.appendingPathComponent("8")
-        let urlSession: URLSession = URLSession(configuration: .ephemeral)
         @Sendable func doOpenUseAndClose() async throws -> String {
             guard
                 let urlComps: URLComponents = URLComponents(
@@ -232,11 +216,6 @@ public struct EasyRacer {
     
     func scenario9() async -> String? {
         let url: URL = baseURL.appendingPathComponent("9")
-        let urlSession: URLSession = URLSession(configuration: {
-            let configuration: URLSessionConfiguration = .ephemeral
-            configuration.httpMaximumConnectionsPerHost = 10 // Default is 6
-            return configuration
-        }())
         
         let result: String? = await withTaskGroup(of: String?.self) { group in
             defer { group.cancelAll() }

--- a/swift-async/Sources/EasyRacer/URLSession.swift
+++ b/swift-async/Sources/EasyRacer/URLSession.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// URLSession operations we actually use in Easy Racer
+protocol URLSession {
+    func data(from url: URL) async throws -> (Data, URLResponse)
+}
+
+/// Make sure the URLSession protocol isn't defining incompatible methods
+extension Foundation.URLSession: URLSession {
+}
+
+/// URLSession implementation that is able to handle 10k concurrent connections
+///
+///  It does this by delegating to Foundation.URLSession, ensuring:
+///   - Each delegatee handles no more than requestsPerSession requests
+///   - Requests are at least timeIntervalBetweenRequests apart
+///     (Needed in some environments, e.g., GitHub Actions)
+actor ScalableURLSession: URLSession {
+    private static let nanosecondsPerSecond: Double = 1_000_000_000
+    
+    private let configuration: URLSessionConfiguration
+    private let requestsPerSession: UInt
+    private let timeIntervalBetweenRequests: TimeInterval
+    
+    private var currentDelegatee: Foundation.URLSession
+    private var currentRequestCount: UInt = 0
+    private var nextRequestNotBefore: Date = .distantPast
+    private var delegatee: Foundation.URLSession {
+        get {
+            if currentRequestCount < requestsPerSession {
+                currentRequestCount += 1
+                return currentDelegatee
+            } else {
+                currentDelegatee.finishTasksAndInvalidate()
+                currentDelegatee = Foundation.URLSession(configuration: configuration)
+                currentRequestCount = 0
+                
+                return currentDelegatee
+            }
+        }
+    }
+    
+    init(
+        configuration: URLSessionConfiguration,
+        requestsPerSession: UInt = 100,
+        timeIntervalBetweenRequests: TimeInterval = 0.001
+    ) {
+        self.configuration = configuration
+        self.requestsPerSession = requestsPerSession
+        self.timeIntervalBetweenRequests = timeIntervalBetweenRequests
+        self.currentDelegatee = Foundation.URLSession(
+            configuration: configuration
+        )
+    }
+    
+    func data(from url: URL) async throws -> (Data, URLResponse) {
+        let delay: TimeInterval = nextRequestNotBefore.timeIntervalSinceNow
+        if delay > 0 {
+            nextRequestNotBefore = nextRequestNotBefore
+                .addingTimeInterval(timeIntervalBetweenRequests)
+            try await Task.sleep(
+                nanoseconds: UInt64(delay * Self.nanosecondsPerSecond)
+            )
+        } else {
+            nextRequestNotBefore = Date()
+                .addingTimeInterval(timeIntervalBetweenRequests)
+        }
+        
+        return try await delegatee.data(from: url)
+    }
+}


### PR DESCRIPTION
OK, finally, a swift-async solution that is reliable on GitHub Actions with Testcontainers cloud.

Some notes:
- Introduced what I'm calling `ScalableURLSession` that is meant to be a drop in replacement for Apple's `URLSession`, but is able to handle 10k connections reliably on GitHub Actions. This is in a separate `URLSession.swift` as I feel it would just be noise in `EasyRacer.swift`.
- Removed code related to URLSession stability from `EasyRacer.swift`, making the racing logic more idiomatic and easier to follow.

(PR from the github.com/jamesward/easyracer repository so as to be able to verify Testcontainers Cloud is working)