### PR TITLE
Implement swift-combine scenario 4 timeout using the Publisher.timeout operator

### DIFF
--- a/swift-combine/Sources/EasyRacer/EasyRacer.swift
+++ b/swift-combine/Sources/EasyRacer/EasyRacer.swift
@@ -79,14 +79,8 @@ public struct EasyRacer {
         let publisher = urlSession
             .bodyTextTaskPublisher(for: url)
             .map { $0 }.replaceError(with: nil)
-        let publisher1SecTimeout = Foundation.URLSession(
-            configuration: {
-                let configuration: URLSessionConfiguration = .ephemeral
-                configuration.timeoutIntervalForRequest = 1
-                return configuration
-            }())
-            .bodyTextTaskPublisher(for: url)
-            .map { $0 }.replaceError(with: nil)
+        let publisher1SecTimeout = publisher
+            .timeout(.seconds(1), scheduler: dispatchQueue)
         
         return publisher.merge(with: publisher1SecTimeout)
             .compactMap { $0 }.first()


### PR DESCRIPTION
This is simpler than the non-Combine implementations that needed a dedicated URLSession.

It also demonstrates that Combine's `timeout` properly cancel's the underlying HTTP connection.