### PR TITLE
scala-akkastreams Set up OkHttp to use virtual threads.

### DIFF
--- a/scala-akkastreams/src/main/scala/EasyRacerClient.scala
+++ b/scala-akkastreams/src/main/scala/EasyRacerClient.scala
@@ -6,6 +6,7 @@ import com.sun.management.OperatingSystemMXBean
 
 import java.lang.management.ManagementFactory
 import java.security.MessageDigest
+import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 import scala.util.Random
 //import akka.http.scaladsl.Http
@@ -174,7 +175,7 @@ object EasyRacerClient:
   import EasyRacerClient.*
   implicit val system: ActorSystem = ActorSystem("easyracer")
   implicit val ec: ExecutionContext = system.dispatcher
-  val okHttpDispatcher = Dispatcher()
+  val okHttpDispatcher = Dispatcher(Executors.newVirtualThreadPerTaskExecutor())
   okHttpDispatcher.setMaxRequests(10_000)
   okHttpDispatcher.setMaxRequestsPerHost(10_000)
   // Akka HTTP does not handle request cancellation, hence using OkHttp adapted to Akka Streams


### PR DESCRIPTION
While doing a couple of test runs of the original Akka Streams implementation, I observed that it was using 10k+ threads. It turns out that OkHttp is creating 1 thread per concurrent connection 🐼:
<img width="671" alt="Screenshot 2024-07-30 at 5 53 49 AM" src="https://github.com/user-attachments/assets/e2255db6-8281-4908-81c2-5097988bf899">

As a stop gap solution, I'm using Loom virtual threads.

This weekend, I'll try migrating to [AsyncHttpClient](https://github.com/AsyncHttpClient/async-http-client), which appears to [handle request cancellations](https://softwaremill.com/cancelling-http-requests-on-the-jvm/) as well.