### PR TITLE
Scala Gears using AsyncHttpClient

### DIFF
--- a/scala-gears/build.sbt
+++ b/scala-gears/build.sbt
@@ -3,6 +3,7 @@ scalaVersion := "3.4.2"
 libraryDependencies ++= Seq(
   "ch.epfl.lamp" %% "gears" % "0.2.0",
   "com.squareup.okhttp3" % "okhttp" % "4.12.0",
+  "org.asynchttpclient" % "async-http-client" % "3.0.0",
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   "org.slf4j" % "slf4j-simple" % "2.0.13" % Test,
   "com.dimafeng" %% "testcontainers-scala-core" % "0.41.4" % Test


### PR DESCRIPTION
The Gears folks seem to prefer using an asynchronous HTTP client:
> Note though that it should generally be avoided to have such long-running, not awaiting (especially: blocking) code, because it occupies a carrier thread. You should instead try to wrap the async API which does lend more to our idioms:

([Source](https://github.com/lampepfl/gears/discussions/89#:~:text=Note%20though%20that%20it%20should%20generally%20be%20avoided%20to%20have%20such%20long%2Drunning%2C%20not%20awaiting%20(especially%3A%20blocking)%20code%2C%20because%20it%20occupies%20a%20carrier%20thread.%20You%20should%20instead%20try%20to%20wrap%20the%20async%20API%20which%20does%20lend%20more%20to%20our%20idioms%3A))

The reason is unclear to me though, as Gears uses Loom threads, and requires Java 21 to run.