### PR TITLE
Prototyping the >> syntax for piping to a single operator

### DIFF
--- a/python-rxpy/main.py
+++ b/python-rxpy/main.py
@@ -13,6 +13,7 @@ from reactivex import operators as ops
 from reactivex.scheduler.eventloop import AsyncIOThreadSafeScheduler
 
 
+# Add >> to reactivex.Observable
 rx.Observable.__rshift__ = lambda self, op: self.pipe(op)
 
 

--- a/python-rxpy/main.py
+++ b/python-rxpy/main.py
@@ -8,13 +8,12 @@ from typing import Callable, Coroutine, Any
 
 import aiohttp
 import psutil
-import reactivex
 import reactivex as rx
 from reactivex import operators as ops
 from reactivex.scheduler.eventloop import AsyncIOThreadSafeScheduler
 
 
-reactivex.Observable.__rshift__ = lambda self, op: self.pipe(op)
+rx.Observable.__rshift__ = lambda self, op: self.pipe(op)
 
 
 # Note: Request creation code is intentionally not shared across scenarios

--- a/python-rxpy/main.py
+++ b/python-rxpy/main.py
@@ -8,9 +8,13 @@ from typing import Callable, Coroutine, Any
 
 import aiohttp
 import psutil
+import reactivex
 import reactivex as rx
 from reactivex import operators as ops
 from reactivex.scheduler.eventloop import AsyncIOThreadSafeScheduler
+
+
+reactivex.Observable.__rshift__ = lambda self, op: self.pipe(op)
 
 
 # Note: Request creation code is intentionally not shared across scenarios
@@ -22,7 +26,7 @@ async def scenario1(url: str) -> rx.Observable[str]:
 
     def req(): return rx.from_future(asyncio.ensure_future(_req()))
 
-    return rx.merge(req(), req()).pipe(ops.first())
+    return rx.merge(req(), req()) >> ops.first()
 
 
 async def scenario2(url: str):
@@ -31,9 +35,9 @@ async def scenario2(url: str):
             async with session.get(url) as response:
                 return await response.text()
 
-    def req(): return rx.from_future(asyncio.ensure_future(http_get())).pipe(ops.catch(rx.empty()))
+    def req(): return rx.from_future(asyncio.ensure_future(http_get())) >> ops.catch(rx.empty())
 
-    return rx.merge(req(), req()).pipe(ops.first())
+    return rx.merge(req(), req()) >> ops.first()
 
 
 async def scenario3(url: str):
@@ -44,7 +48,7 @@ async def scenario3(url: str):
 
     def req(): return rx.from_future(asyncio.ensure_future(_req()))
 
-    return rx.merge(*[req() for req in [req] * 10_000]).pipe(ops.first())
+    return rx.merge(*[req() for req in [req] * 10_000]) >> ops.first()
 
 
 async def scenario4(url: str):
@@ -56,12 +60,9 @@ async def scenario4(url: str):
     def req(): return rx.from_future(asyncio.ensure_future(_req()))
 
     return rx.merge(
-        req().pipe(
-            ops.timeout(datetime.timedelta(seconds=1)),
-            ops.catch(rx.empty())
-        ),
+        req() >> ops.timeout(datetime.timedelta(seconds=1)) >> ops.catch(rx.empty()),
         req()
-    ).pipe(ops.first())
+    ) >> ops.first()
 
 
 async def scenario5(url: str):
@@ -71,9 +72,9 @@ async def scenario5(url: str):
                 response.raise_for_status()
                 return await response.text()
 
-    def req(): return rx.from_future(asyncio.ensure_future(_req())).pipe(ops.catch(rx.empty()))
+    def req(): return rx.from_future(asyncio.ensure_future(_req())) >> ops.catch(rx.empty())
 
-    return rx.merge(req(), req()).pipe(ops.first())
+    return rx.merge(req(), req()) >> ops.first()
 
 
 async def scenario6(url: str):
@@ -83,9 +84,9 @@ async def scenario6(url: str):
                 response.raise_for_status()
                 return await response.text()
 
-    def req(): return rx.from_future(asyncio.ensure_future(_req())).pipe(ops.catch(rx.empty()))
+    def req(): return rx.from_future(asyncio.ensure_future(_req())) >> ops.catch(rx.empty())
 
-    return rx.merge(req(), req(), req()).pipe(ops.first())
+    return rx.merge(req(), req(), req()) >> ops.first()
 
 
 async def scenario7(url: str) -> rx.Observable[str]:
@@ -95,12 +96,9 @@ async def scenario7(url: str) -> rx.Observable[str]:
                 return await response.text()
 
     def req(): return rx.from_future(asyncio.ensure_future(_req()))
-    hedge_req = rx.of(()).pipe(
-        ops.delay(datetime.timedelta(seconds=3)),
-        ops.flat_map(lambda _: req())
-    )
+    hedge_req = rx.of(()) >> ops.delay(datetime.timedelta(seconds=3)) >> ops.flat_map(lambda _: req())
 
-    return rx.merge(req(), hedge_req).pipe(ops.first())
+    return rx.merge(req(), hedge_req) >> ops.first()
 
 
 async def scenario8(base_url: str) -> rx.Observable[str]:
@@ -117,22 +115,15 @@ async def scenario8(base_url: str) -> rx.Observable[str]:
     def close_req(res: str): return rx.from_future(asyncio.ensure_future(_req(f"{base_url}?close={res}")))
 
     def res_req():
-        return open_req().pipe(
-            ops.flat_map(
-                lambda res: use_req(res).pipe(
-                    ops.catch(rx.of(None)),
-                    ops.flat_map(
-                        lambda result: close_req(res).pipe(
-                            ops.flat_map(
-                                lambda _: rx.empty() if result is None else rx.of(result)
-                            )
-                        )
-                    )
+        return open_req() >> ops.flat_map(
+            lambda res: use_req(res) >> ops.catch(rx.of(None)) >> ops.flat_map(
+                lambda result: close_req(res) >> ops.flat_map(
+                    lambda _: rx.empty() if result is None else rx.of(result)
                 )
             )
         )
 
-    return rx.merge(res_req(), res_req()).pipe(ops.first())
+    return rx.merge(res_req(), res_req()) >> ops.first()
 
 
 async def scenario9(url: str):
@@ -142,11 +133,9 @@ async def scenario9(url: str):
                 response.raise_for_status()
                 return await response.text()
 
-    def req(): return rx.from_future(asyncio.ensure_future(_req())).pipe(ops.catch(rx.empty()))
+    def req(): return rx.from_future(asyncio.ensure_future(_req())) >> ops.catch(rx.empty())
 
-    return rx.merge(*[req() for req in [req] * 10]).pipe(
-        ops.reduce(lambda x, y: x + y)
-    )
+    return rx.merge(*[req() for req in [req] * 10]) >> ops.reduce(lambda x, y: x + y)
 
 
 async def scenario10(base_url: str) -> rx.Observable[str]:
@@ -165,10 +154,10 @@ async def scenario10(base_url: str) -> rx.Observable[str]:
         m.update(bs)
         return m.digest()
 
-    def blocking(): return rx.repeat_value(()).pipe(
-        ops.scan(lambda accum, _: _busy(accum), seed=random.randbytes(512)),
-        ops.map(lambda _: None)
-    )
+    def blocking():
+        return (rx.repeat_value(())
+                >> ops.scan(lambda accum, _: _busy(accum), seed=random.randbytes(512))
+                >> ops.map(lambda _: None))
 
     def blocker(): return rx.from_future(asyncio.ensure_future(_req(f"{base_url}?{req_id}")))
 
@@ -178,28 +167,20 @@ async def scenario10(base_url: str) -> rx.Observable[str]:
                 case 200:
                     return rx.of(response.body_text)
                 case 302:
-                    return rx.of(()).pipe(
-                        ops.delay(datetime.timedelta(seconds=1)),
-                        ops.flat_map(reporter())
-                    )
+                    return rx.of(()) >> ops.delay(datetime.timedelta(seconds=1)) >> ops.flat_map(reporter())
 
         with p.oneshot():
             load = p.cpu_percent()
             return rx.from_future(
                 asyncio.ensure_future(_req(f"{base_url}?{req_id}={load}"))
-            ).pipe(
-                ops.flat_map(handle_response)
-            )
+            ) >> ops.flat_map(handle_response)
 
     return rx.merge(
-        rx.merge(blocking(), blocker()).pipe(
-            ops.first(lambda value: value is not None),
-            ops.map(lambda _: None)
-        ),
+        rx.merge(
+            blocking(), blocker()
+        ) >> ops.first(lambda value: value is not None) >> ops.map(lambda _: None),
         reporter()
-    ).pipe(
-        ops.first(lambda value: value is not None),
-    )
+    ) >> ops.first(lambda value: value is not None)
 
 
 scenarios: list[Callable[[str], Coroutine[Any, Any, rx.Observable[str]]]] = [


### PR DESCRIPTION
Working with F# got me to realize Python's `pipe()` could be written as `>>` (right shift).

This draft PR is just me experimenting with the idea.

I have also created a [PR against RxPY introducing >> there](https://github.com/ReactiveX/RxPY/pull/720). Hopefully they'll accept it and make it official.