### PR TITLE
Python RxPY await scenario Observables

### DIFF
--- a/python-rxpy/.gitignore
+++ b/python-rxpy/.gitignore
@@ -1,3 +1,4 @@
 /.pyenv/
 /venv/
 /__pycache__/
+/.python-version

--- a/python-rxpy/main.py
+++ b/python-rxpy/main.py
@@ -10,7 +10,6 @@ import aiohttp
 import psutil
 import reactivex as rx
 from reactivex import operators as ops
-from reactivex.scheduler.eventloop import AsyncIOThreadSafeScheduler
 
 
 # Note: Request creation code is intentionally not shared across scenarios

--- a/python-rxpy/test_all.py
+++ b/python-rxpy/test_all.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import pytest
 from testcontainers.core.generic import DockerContainer
 

--- a/python-rxpy/test_all.py
+++ b/python-rxpy/test_all.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import pytest
-from reactivex.scheduler.eventloop import AsyncIOThreadSafeScheduler
 from testcontainers.core.generic import DockerContainer
 
 import main
@@ -25,21 +24,11 @@ async def test_all():
 
         #@wait_container_is_ready()
         async def connected():
-            scheduler = AsyncIOThreadSafeScheduler(asyncio.get_event_loop())
-            sem = asyncio.Semaphore(0)
-
             def assert_right(actual: str):
                 assert actual == "right"
             for scenario in main.scenarios:
                 num = scenario.__name__[8:]
                 url = f"http://localhost:{port}/{num}"
-                scenario_observable = await scenario(url)
-                scenario_observable.subscribe(
-                    on_next=lambda value: assert_right(value),
-                    on_completed=lambda: sem.release(),
-                    scheduler=scheduler
-                )
-                await sem.acquire()
-
+                assert_right(await scenario(url))
 
         await connected()


### PR DESCRIPTION
While working on something unrelated, I noticed from reading the source that Observables are awaitable (defines `__await__()`).

Awaiting on an Observable:
- Runs the observable, much like documented behaviors: `subscribe(...)` or `run()`
- [Automatically uses `reactivex.scheduler.eventloop.AsyncIOScheduler`](https://github.com/ReactiveX/RxPY/blob/be64ef3d759d38f4e0198704fe6578cff96ea21c/reactivex/observable/observable.py#L271) (reducing boilerplate)
- Eliminates the need to manually synchronize with semaphores

It is interesting to note that revisiting their documentation, even the section of asyncio integration fails to mention this.

This PR also made all scenarios synchronous (replaced `async def scenario##()` with `def scenario##()`), as they never needed to be `async`. I think I just made everything `async` while trying to figure out RxPY asyncio integration.