### PR TITLE
Scala Soundness scenario 9 to use `mend`/`.within` instead of `try`/`catch`

### DIFF
--- a/scala-soundness/src/main/scala/EasyRacerClient.scala
+++ b/scala-soundness/src/main/scala/EasyRacerClient.scala
@@ -152,7 +152,7 @@ def scenario11(scenarioUrl: Text => HttpUrl): Text raises HttpError raises Concu
 val scenarios: Seq[(Text => HttpUrl) => Text raises HttpError raises ConcurrencyError] = Seq(
   scenario1,
   scenario2,
-//  scenario3,
+  scenario3,
   scenario4,
   scenario5,
   scenario6,

--- a/scala-soundness/src/main/scala/EasyRacerClient.scala
+++ b/scala-soundness/src/main/scala/EasyRacerClient.scala
@@ -88,14 +88,14 @@ def scenario8(scenarioUrl: Text => HttpUrl): Text raises HttpError raises Concur
     Seq(async(reqRes), async(reqRes)).race()
 
 def scenario9(scenarioUrl: Text => HttpUrl): Text raises HttpError raises ConcurrencyError =
-  def req = scenarioUrl(t"9").get().as[Text]
+  def req =
+    mend:
+      case HttpError(_, _) => t""
+    .within:
+      scenarioUrl(t"9").get().as[Text]
   supervise:
     Seq.fill(10):
-      async:
-        mend:
-          case HttpError(_, _) => t""
-        .within(req)
-      .map(System.nanoTime() -> _)
+      async(req).map(System.nanoTime() -> _)
     .sequence
     .map(_.sortBy(_._1).map(_._2).reduce(_ + _))
     .await()
@@ -151,7 +151,7 @@ def scenario11(scenarioUrl: Text => HttpUrl): Text raises HttpError raises Concu
 val scenarios: Seq[(Text => HttpUrl) => Text raises HttpError raises ConcurrencyError] = Seq(
   scenario1,
   scenario2,
-  scenario3,
+//  scenario3,
   scenario4,
   scenario5,
   scenario6,


### PR DESCRIPTION
`mend`/`.within` is the idiomatic approach to exception handling in Soundness

Based on [feedback](https://github.com/jackgene/easyracer/commit/ae371538363d7676617447c55ff50ffc0a8364ff#commitcomment-150797104) from @propensive.

Jon, based on your feedback I was able to simply explicitly annotate the type of `req` as `Text raises HttpError`, and that seemed to work. Let me know if you have any concerns with it.

I also considered defining the `async` block within its own method (in fact I considered doing that for all scenarios earlier on), but decided against it to make the implementation more consistent with all the other implementations.