### PR TITLE
Upgrade to Swift 6

### DIFF
--- a/swift-async/Package.swift
+++ b/swift-async/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/swift-async/Sources/EasyRacer/EasyRacer.swift
+++ b/swift-async/Sources/EasyRacer/EasyRacer.swift
@@ -22,7 +22,7 @@ extension URLSession {
 }
 
 @main
-public struct EasyRacer {
+public struct EasyRacer: Sendable {
     let baseURL: URL
     let urlSession: some URLSession = ScalableURLSession(
         configuration: {

--- a/swift-async/Sources/EasyRacer/URLSession.swift
+++ b/swift-async/Sources/EasyRacer/URLSession.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// URLSession operations we actually use in Easy Racer
-protocol URLSession {
+protocol URLSession: Sendable {
     func data(from url: URL) async throws -> (Data, URLResponse)
 }
 


### PR DESCRIPTION
Made `EasyRacer` and `URLSession` `Sendable` so that Swift 6 data-race-safety checking knows that they are thread-safe.