### PR TITLE
Upgrade swift-combine to Swift 6

### DIFF
--- a/.github/workflows/clients.pkl
+++ b/.github/workflows/clients.pkl
@@ -183,7 +183,7 @@ clients = new Mapping<String, Run> {
   }
 
   ["swift-combine"] = new {
-    `runs-on` = "macos-latest"
+    `runs-on` = "macos-15"
     steps = swiftSteps
   }
 

--- a/.github/workflows/swift-combine.yaml
+++ b/.github/workflows/swift-combine.yaml
@@ -30,7 +30,7 @@ jobs:
         sleep 2
         sudo chmod a+rw /var/run/docker.sock
     - name: Run scenarios
-      run: swift test -c release
+      run: swift test
     defaults:
       run:
         working-directory: swift-combine

--- a/.github/workflows/swift-combine.yaml
+++ b/.github/workflows/swift-combine.yaml
@@ -15,7 +15,7 @@
     - completed
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-15
     if: ${{ github.event.workflow_run == null || github.event.workflow_run.conclusion == 'success' }}
     steps:
     - uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
         sleep 2
         sudo chmod a+rw /var/run/docker.sock
     - name: Run scenarios
-      run: swift test
+      run: swift test -c release
     defaults:
       run:
         working-directory: swift-combine

--- a/swift-combine/Package.swift
+++ b/swift-combine/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/swift-combine/Sources/EasyRacer/Publishers+Repeating.swift
+++ b/swift-combine/Sources/EasyRacer/Publishers+Repeating.swift
@@ -2,7 +2,7 @@ import Atomics
 import Combine
 
 extension Publishers {
-    struct Repeating<Output>: Publisher {
+    struct Repeating<Output>: Publisher where Output : Sendable {
         typealias Failure = Never
         
         private let element: Output
@@ -11,15 +11,15 @@ extension Publishers {
             self.element = element
         }
         
-        func receive<S>(subscriber: S) where S : Subscriber, Never == S.Failure, Output == S.Input {
+        func receive<S>(subscriber: S) where S : Subscriber & Sendable, Never == S.Failure, Output == S.Input {
             let subscription: some Subscription = RepeatingSubscription(element, subscriber)
             subscriber.receive(subscription: subscription)
         }
         
-        final class RepeatingSubscription<Downstream: Subscriber>: Subscription where Downstream.Input == Output, Downstream.Failure == Never {
+        final class RepeatingSubscription<Downstream>: Subscription, Sendable where Downstream : Subscriber & Sendable, Downstream.Input == Output, Downstream.Failure == Never {
             private let element: Output
             private let subscriber: Downstream
-            private var active: ManagedAtomic<Bool> = ManagedAtomic(true)
+            private let active: ManagedAtomic<Bool> = ManagedAtomic(true)
             
             init(_ element: Output, _ subscriber: Downstream) {
                 self.element = element


### PR DESCRIPTION
Mostly marking things `Sendable`, and making variables immutable where they didn't need to be to satisfy Swift 6's data race safety checks.