### PR TITLE
Take advantage of some minor Swift 6.1 improvements

### DIFF
--- a/.github/workflows/clients.pkl
+++ b/.github/workflows/clients.pkl
@@ -173,7 +173,7 @@ clients = new Mapping<String, Run> {
     }
     new {
       name = "Select Xcode version"
-      run = "xcode-select -s '/Applications/Xcode_16.3.app/Contents/Developer'"
+      run = "sudo xcode-select -s '/Applications/Xcode_16.3.app/Contents/Developer'"
     }
     new {
       name = "Run scenarios"

--- a/.github/workflows/clients.pkl
+++ b/.github/workflows/clients.pkl
@@ -177,7 +177,7 @@ clients = new Mapping<String, Run> {
     }
     new {
       name = "Run scenarios"
-      run = "swift test --disable-swift-testing -c release"
+      run = "swift test --disable-swift-testing"
     }
   }
 

--- a/.github/workflows/clients.pkl
+++ b/.github/workflows/clients.pkl
@@ -177,7 +177,7 @@ clients = new Mapping<String, Run> {
     }
     new {
       name = "Run scenarios"
-      run = "swift test -c release"
+      run = "swift test --disable-swift-testing -c release"
     }
   }
 

--- a/.github/workflows/clients.pkl
+++ b/.github/workflows/clients.pkl
@@ -172,8 +172,12 @@ clients = new Mapping<String, Run> {
         """
     }
     new {
+      name = "Select Xcode version"
+      run = "xcode-select -s '/Applications/Xcode_16.3.app/Contents/Developer'"
+    }
+    new {
       name = "Run scenarios"
-      run = "swift test"
+      run = "swift test -c release"
     }
   }
 
@@ -251,3 +255,4 @@ output {
     }))
     .toMapping()
 }
+

--- a/.github/workflows/swift-async.yaml
+++ b/.github/workflows/swift-async.yaml
@@ -30,7 +30,7 @@ jobs:
         sleep 2
         sudo chmod a+rw /var/run/docker.sock
     - name: Select Xcode version
-      run: xcode-select -s '/Applications/Xcode_16.3.app/Contents/Developer'
+      run: sudo xcode-select -s '/Applications/Xcode_16.3.app/Contents/Developer'
     - name: Run scenarios
       run: swift test -c release
     defaults:

--- a/.github/workflows/swift-async.yaml
+++ b/.github/workflows/swift-async.yaml
@@ -32,7 +32,7 @@ jobs:
     - name: Select Xcode version
       run: sudo xcode-select -s '/Applications/Xcode_16.3.app/Contents/Developer'
     - name: Run scenarios
-      run: swift test --disable-swift-testing -c release
+      run: swift test --disable-swift-testing
     defaults:
       run:
         working-directory: swift-async

--- a/.github/workflows/swift-async.yaml
+++ b/.github/workflows/swift-async.yaml
@@ -29,8 +29,10 @@ jobs:
         sudo socat UNIX-LISTEN:/var/run/docker.sock,reuseaddr,fork TCP-CONNECT:127.0.0.1:$DOCKER_PORT &
         sleep 2
         sudo chmod a+rw /var/run/docker.sock
+    - name: Select Xcode version
+      run: xcode-select -s '/Applications/Xcode_16.3.app/Contents/Developer'
     - name: Run scenarios
-      run: swift test
+      run: swift test -c release
     defaults:
       run:
         working-directory: swift-async

--- a/.github/workflows/swift-async.yaml
+++ b/.github/workflows/swift-async.yaml
@@ -32,7 +32,7 @@ jobs:
     - name: Select Xcode version
       run: sudo xcode-select -s '/Applications/Xcode_16.3.app/Contents/Developer'
     - name: Run scenarios
-      run: swift test -c release
+      run: swift test --disable-swift-testing -c release
     defaults:
       run:
         working-directory: swift-async

--- a/.github/workflows/swift-combine.yaml
+++ b/.github/workflows/swift-combine.yaml
@@ -29,8 +29,10 @@ jobs:
         sudo socat UNIX-LISTEN:/var/run/docker.sock,reuseaddr,fork TCP-CONNECT:127.0.0.1:$DOCKER_PORT &
         sleep 2
         sudo chmod a+rw /var/run/docker.sock
+    - name: Select Xcode version
+      run: sudo xcode-select -s '/Applications/Xcode_16.3.app/Contents/Developer'
     - name: Run scenarios
-      run: swift test -c release
+      run: swift test --disable-swift-testing
     defaults:
       run:
         working-directory: swift-combine

--- a/swift-async/Sources/EasyRacer/EasyRacer.swift
+++ b/swift-async/Sources/EasyRacer/EasyRacer.swift
@@ -38,7 +38,7 @@ public struct EasyRacer: Sendable {
     func scenario1() async -> String? {
         let url: URL = baseURL.appending(path: "1")
         
-        let result: String? = await withTaskGroup(of: String?.self) { group in
+        let result: String? = await withTaskGroup { group in
             defer { group.cancelAll() }
             
             group.addTask { try? await urlSession.bodyText(from: url) }
@@ -53,7 +53,7 @@ public struct EasyRacer: Sendable {
     func scenario2() async -> String? {
         let url: URL = baseURL.appending(path: "2")
         
-        let result: String? = await withTaskGroup(of: String?.self) { group in
+        let result: String? = await withTaskGroup { group in
             defer { group.cancelAll() }
             
             group.addTask { try? await urlSession.bodyText(from: url) }
@@ -68,7 +68,7 @@ public struct EasyRacer: Sendable {
     func scenario3() async -> String? {
         let url: URL = baseURL.appending(path: "3")
         
-        let result: String? = await withTaskGroup(of: String?.self) { group in
+        let result: String? = await withTaskGroup { group in
             defer { group.cancelAll() }
             
             for _ in 1...10_000 {
@@ -91,7 +91,7 @@ public struct EasyRacer: Sendable {
             return configuration
         }())
         
-        let result: String? = await withTaskGroup(of: String?.self) { group in
+        let result: String? = await withTaskGroup { group in
             defer { group.cancelAll() }
             
             group.addTask { try? await urlSession.bodyText(from: url) }
@@ -106,7 +106,7 @@ public struct EasyRacer: Sendable {
     func scenario5() async -> String? {
         let url: URL = baseURL.appending(path: "5")
         
-        let result: String? = await withTaskGroup(of: String?.self) { group in
+        let result: String? = await withTaskGroup { group in
             defer { group.cancelAll() }
             
             group.addTask { try? await urlSession.bodyText(from: url) }
@@ -121,7 +121,7 @@ public struct EasyRacer: Sendable {
     func scenario6() async -> String? {
         let url: URL = baseURL.appending(path: "6")
         
-        let result: String? = await withTaskGroup(of: String?.self) { group in
+        let result: String? = await withTaskGroup { group in
             defer { group.cancelAll() }
             
             group.addTask { try? await urlSession.bodyText(from: url) }
@@ -137,7 +137,7 @@ public struct EasyRacer: Sendable {
     func scenario7() async -> String? {
         let url: URL = baseURL.appending(path: "7")
         
-        let result: String? = await withTaskGroup(of: String?.self) { group in
+        let result: String? = await withTaskGroup { group in
             defer { group.cancelAll() }
             
             group.addTask { try? await urlSession.bodyText(from: url) }
@@ -176,7 +176,7 @@ public struct EasyRacer: Sendable {
             return text
         }
         
-        let result: String? = await withTaskGroup(of: String?.self) { group in
+        let result: String? = await withTaskGroup { group in
             defer { group.cancelAll() }
             
             group.addTask { try? await doOpenUseAndClose() }
@@ -191,7 +191,7 @@ public struct EasyRacer: Sendable {
     func scenario9() async -> String? {
         let url: URL = baseURL.appending(path: "9")
         
-        let result: String? = await withTaskGroup(of: String?.self) { group in
+        let result: String? = await withTaskGroup { group in
             defer { group.cancelAll() }
             
             for _ in 1...10 {
@@ -275,7 +275,7 @@ public struct EasyRacer: Sendable {
         }
         
         // Run blocker
-        async let blockerResult: Void? = withTaskGroup(of: Void?.self) { group in
+        async let blockerResult: Void? = withTaskGroup { group in
             defer { group.cancelAll() }
             
             group.addTask { try? await request() }
@@ -295,11 +295,13 @@ public struct EasyRacer: Sendable {
     func scenario11() async -> String? {
         let url: URL = baseURL.appending(path: "11")
         
-        let result: String? = await withTaskGroup(of: String?.self) { group in
+        let result: String? = await withTaskGroup { group in
             defer { group.cancelAll() }
             
             group.addTask {
-                await withTaskGroup(of: String?.self) { subgroup in
+                await withTaskGroup { subgroup in
+                    defer { subgroup.cancelAll() }
+                    
                     subgroup.addTask { try? await urlSession.bodyText(from: url) }
                     subgroup.addTask { try? await urlSession.bodyText(from: url) }
                     
@@ -307,7 +309,7 @@ public struct EasyRacer: Sendable {
                 }
             }
             group.addTask { try? await urlSession.bodyText(from: url) }
-            
+
             return await group.first { $0 != nil }.flatMap { $0 }
         }
         


### PR DESCRIPTION
In Swift 6.1 `withTaskGroup` no longer needs to be called with the `of` parameter, as it is able to [infer the return type from the closure return type](https://www.swift.org/blog/swift-6.1-released/#:~:text=Swift%206.1%20also%20improves%20type%20inference%20for%20task%20groups%20by%20inferring%20the%20child%20task%20result%20type%20of%20withTaskGroup%20and%20withThrowingTaskGroup.%20Previously%2C%20you%20always%20had%20to%20write%20the%20child%20task%20result%20type%20as%20an%20argument%20when%20creating%20the%20task%20group%3A).