### PR TITLE
Use Swift's built-in Atomics.

### DIFF
--- a/swift-combine/Package.swift
+++ b/swift-combine/Package.swift
@@ -6,18 +6,14 @@ import PackageDescription
 let package = Package(
     name: "EasyRacer",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v15)
     ],
     dependencies: [
         .package(url: "https://github.com/alexsteinerde/docker-client-swift.git", from: "0.1.2"),
-        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
     ],
     targets: [
         .executableTarget(
-            name: "EasyRacer",
-            dependencies: [
-                .product(name: "Atomics", package: "swift-atomics"),
-            ]),
+            name: "EasyRacer"),
         .testTarget(
             name: "EasyRacerTests",
             dependencies: [

--- a/swift-combine/Sources/EasyRacer/EasyRacer.swift
+++ b/swift-combine/Sources/EasyRacer/EasyRacer.swift
@@ -261,7 +261,7 @@ public struct EasyRacer {
             .eraseToAnyPublisher()
     }
     
-    public func scenarios() -> AnyPublisher<[String?], Never> {
+    public func scenarios() -> AnyPublisher<(Int, String?), Never> {
         let scenarios = [
             (1, scenario1()),
             (2, scenario2()),
@@ -280,10 +280,6 @@ public struct EasyRacer {
                 let (num, scenario) = scenarioAndNumber
                 return scenario.map { $0 }.replaceEmpty(with: nil).map { (num, $0) }
             }
-            .collect()
-            .map { results in
-                results.sorted { $0.0 < $1.0 }.map { $0.1 }
-            }
             .eraseToAnyPublisher()
     }
     
@@ -298,13 +294,9 @@ public struct EasyRacer {
             EasyRacer(baseURL: baseURL).scenarios()
                 .sink(
                     receiveCompletion: { _ in completed.signal() },
-                    receiveValue: { results in
-                        for (idx, result) in results.enumerated() {
-                            print("Scenario \(idx + 1): \(result ?? "error")")
-                        }
-                        if !results.allSatisfy({ $0 != nil }) {
-                            exit(EXIT_FAILURE)
-                        }
+                    receiveValue: { scenarioAndResult in
+                        let (scenario, result) = scenarioAndResult
+                        print("Scenario \(scenario): \(result ?? "error")")
                     }
                 )
                 .store(in: &subscriptions)

--- a/swift-combine/Sources/EasyRacer/Publishers+Repeating.swift
+++ b/swift-combine/Sources/EasyRacer/Publishers+Repeating.swift
@@ -1,5 +1,5 @@
-import Atomics
 import Combine
+import Synchronization
 
 extension Publishers {
     struct Repeating<Output>: Publisher where Output : Sendable {
@@ -19,7 +19,7 @@ extension Publishers {
         final class RepeatingSubscription<Downstream>: Subscription, Sendable where Downstream : Subscriber & Sendable, Downstream.Input == Output, Downstream.Failure == Never {
             private let element: Output
             private let subscriber: Downstream
-            private let active: ManagedAtomic<Bool> = ManagedAtomic(true)
+            private let active: Atomic<Bool> = Atomic(true)
             
             init(_ element: Output, _ subscriber: Downstream) {
                 self.element = element


### PR DESCRIPTION
Starting Swift 6 and macOS 15, Atomics is part of the standard library and no longer needs to be pulled in as a dependency.