### PR TITLE
fix(typescript-effect): ignore non-2xx responses in scenario 9

### DIFF
--- a/typescript-effect/src/lib.ts
+++ b/typescript-effect/src/lib.ts
@@ -129,7 +129,7 @@ export function scenario9(port: number) {
                 const text = yield* valid.text
                 yield* Queue.offer(responses, text)
             })
-        )
+        ).pipe(Effect.ignore)
 
         yield* Effect.all(Array.replicate(req, 10), {concurrency: "unbounded", discard: true})
         return Chunk.toArray(yield* Queue.takeAll(responses)).join("")


### PR DESCRIPTION
Scenario 9 makes 10 concurrent requests where 5 return non-200 responses. The current implementation used `Effect.all` without handling errors, so `filterStatusOk` failures caused the whole aggregation to fail with a 500 error.

This adds `.pipe(Effect.ignore)` to each request so failed responses are dropped and only successful responses are enqueued. This matches the reference implementations (Scala ZIO uses `req.option`, JavaScript stdlib uses `Promise.allSettled`).

Unblocks PRs #1295, #1280, #1273, #1269 which were all failing on this pre-existing issue (introduced in #1296).