### PR TITLE
Update pekko-stream to 1.6.0

### DIFF
--- a/scala-pekko/build.sbt
+++ b/scala-pekko/build.sbt
@@ -1,6 +1,6 @@
 scalaVersion := "3.8.3"
 
-val PekkoVersion = "1.5.0"
+val PekkoVersion = "1.6.0"
 val PekkoHttpVersion = "1.3.0"
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
Rebased version of #1298 on top of latest main (includes async-http-client 3.0.9 and sbt 1.12.11).

Closes #1298