### PR TITLE
scala-kyo: migrate from kyo-sttp to kyo-http (Kyo 1.0.0-RC2)

### DIFF
--- a/scala-kyo/build.sbt
+++ b/scala-kyo/build.sbt
@@ -1,11 +1,10 @@
 scalaVersion := "3.8.4"
 
-libraryDependencySchemes += "io.getkyo" %% "kyo-core" % "always"
-
 libraryDependencies ++= Seq(
   "io.getkyo" %% "kyo-core" % "1.0.0-RC2",
   "io.getkyo" %% "kyo-direct" % "1.0.0-RC2",
-  "io.getkyo" %% "kyo-sttp" % "1.0-RC1",
+  "io.getkyo" %% "kyo-http" % "1.0.0-RC2",
+  "io.getkyo" %% "kyo-logging-slf4j" % "1.0.0-RC2",
   "org.slf4j" % "slf4j-simple" % "2.0.18",
   "org.scalatest" %% "scalatest" % "3.2.20" % Test,
   "com.dimafeng" %% "testcontainers-scala-core" % "0.44.1" % Test

--- a/scala-kyo/src/main/scala/EasyRacerClient.scala
+++ b/scala-kyo/src/main/scala/EasyRacerClient.scala
@@ -1,8 +1,5 @@
 import com.sun.management.OperatingSystemMXBean
 import kyo.*
-import sttp.client3.*
-import sttp.model.Uri.QuerySegment
-import sttp.model.{ResponseMetadata, Uri}
 
 import scala.collection.immutable.SortedMap
 
@@ -12,69 +9,74 @@ import java.security.MessageDigest
 
 object EasyRacerClient extends KyoApp:
 
-  def scenario1(scenarioUrl: Int => Uri) =
+  // The default HttpClient config has a 5s request timeout and follows redirects, neither of which works
+  // for these scenarios: scenarios 7 and 10 hold the connection open for many seconds, and scenario 10
+  // relies on observing 3xx responses from the reporter without auto-following them.
+  private inline def withClient[A, S](v: A < (Async & Abort[HttpException] & S)): A < (Async & Abort[HttpException] & S) =
+    HttpClient.withConfig(_.timeout(Duration.Infinity).followRedirects(false))(v)
+
+  def scenario1(scenarioUrl: Int => String) =
     val url = scenarioUrl(1)
-    val req = Requests(_.get(url))
+    val req = HttpClient.getText(url)
     Async.race(req, req)
 
-  def scenario2(scenarioUrl: Int => Uri) =
+  def scenario2(scenarioUrl: Int => String) =
     val url = scenarioUrl(2)
-    val req = Requests(_.get(url))
+    val req = HttpClient.getText(url)
     Async.race(req, req)
 
-  def scenario3(scenarioUrl: Int => Uri) =
+  def scenario3(scenarioUrl: Int => String) =
     val url = scenarioUrl(3)
     val reqs = Seq.fill(10000):
-      Requests(_.get(url))
+      HttpClient.getText(url)
     Async.race(reqs)
 
-  def scenario4(scenarioUrl: Int => Uri) =
+  def scenario4(scenarioUrl: Int => String) =
     val url = scenarioUrl(4)
-    val req = Requests(_.get(url))
+    val req = HttpClient.getText(url)
     val reqWithTimeout = Async.timeout(1.seconds)(req)
     Async.race(req, reqWithTimeout)
 
-  def scenario5(scenarioUrl: Int => Uri) =
+  def scenario5(scenarioUrl: Int => String) =
     val url = scenarioUrl(5)
-    val req = Requests(_.get(url))
+    val req = HttpClient.getText(url)
     Async.race(req, req)
 
-  def scenario6(scenarioUrl: Int => Uri) =
+  def scenario6(scenarioUrl: Int => String) =
     val url = scenarioUrl(6)
-    val req = Requests(_.get(url))
+    val req = HttpClient.getText(url)
     Async.race(req, req, req)
 
-  def scenario7(scenarioUrl: Int => Uri) =
+  def scenario7(scenarioUrl: Int => String) =
     val url = scenarioUrl(7)
-    val req = Requests(_.get(url))
+    val req = HttpClient.getText(url)
     val delayedReq = Async.delay(4.seconds)(req)
     Async.race(req, delayedReq)
 
-  def scenario8(scenarioUrl: Int => Uri): String < (Abort[FailedRequest] & Async) =
-    def req(uri: Uri) = Requests(_.get(uri))
+  def scenario8(scenarioUrl: Int => String): String < (Abort[HttpException] & Async) =
+    val baseUrl = scenarioUrl(8)
     case class MyResource(id: String):
       def close: Unit < Async =
-        Abort.run(req(uri"${scenarioUrl(8)}?close=$id")).unit
+        Abort.run(HttpClient.getText(s"$baseUrl?close=$id")).unit
 
     val myResource = direct:
-      val id = req(uri"${scenarioUrl(8)}?open").now
-      Resource.acquireRelease(MyResource(id))(_.close).now
+      val id = HttpClient.getText(s"$baseUrl?open").now
+      Scope.acquireRelease(MyResource(id))(_.close).now
 
     val reqRes =
-      Resource.run:
+      Scope.run:
         direct:
           val resource: MyResource = myResource.now
-          req(uri"${scenarioUrl(8)}?use=${resource.id}").now
+          HttpClient.getText(s"$baseUrl?use=${resource.id}").now
 
     Async.race(reqRes, reqRes)
 
-  // todo: maybe some kind of queue instead to avoid the instant
-  def scenario9(scenarioUrl: Int => Uri) =
+  def scenario9(scenarioUrl: Int => String) =
     val url = scenarioUrl(9)
 
     val req =
         direct:
-          val body = Requests(_.get(url)).now
+          val body = HttpClient.getText(url).now
           val now = Clock.now.now
           now -> body
 
@@ -84,59 +86,54 @@ object EasyRacerClient extends KyoApp:
       val successes = SortedMap.from(Async.gather(reqs).now)
       successes.values.mkString
 
-  def scenario10(scenarioUrl: Int => Uri) =
-    // always puts the body into the response, even if it is empty, and includes the responseMetadata
-    def req(uriModifier: Uri => Uri): (String, ResponseMetadata) < (Abort[FailedRequest] & Async) =
-      val uri = uriModifier(scenarioUrl(10))
-      Requests:
-        _.get(uri).response:
-          asString.mapWithMetadata: (stringEither, responseMetadata) =>
-            Right(stringEither.fold(identity, identity) -> responseMetadata)
-
+  def scenario10(scenarioUrl: Int => String) =
+    val baseUrl = scenarioUrl(10)
     val messageDigest = MessageDigest.getInstance("SHA-512")
 
     // recursive digesting
-    def blocking(bytesEffect: Seq[Byte] < (Abort[FailedRequest] & Async)): Seq[Byte] < (Abort[FailedRequest] & Async) =
+    def blocking(bytesEffect: Seq[Byte] < (Abort[HttpException] & Async)): Seq[Byte] < (Abort[HttpException] & Async) =
       Sync.defer:
         bytesEffect.map: bytes =>
           blocking(messageDigest.digest(bytes.toArray).toSeq)
 
     // runs blocking code while the request is open
-    def blocker(id: String): String < (Abort[FailedRequest] & Async) =
+    def blocker(id: String): String < (Abort[HttpException] & Async) =
       Async.race(
-        req(_.addQuerySegment(QuerySegment.Plain(id))).map { (body, _) => body },
+        HttpClient.getText(s"$baseUrl?$id"),
         blocking(Random.nextBytes(512)).map(_ => ""),
       )
 
     // sends CPU usage every second until the server says to stop
-    def reporter(id: String): String < (Abort[FailedRequest] & Async) =
+    def reporter(id: String): String < (Abort[HttpException] & Async) =
       val osBean = ManagementFactory.getPlatformMXBean(classOf[OperatingSystemMXBean])
       val load = osBean.getProcessCpuLoad * osBean.getAvailableProcessors
 
       direct:
-        val (maybeResponseBody, responseMetadata) =
-          req(_.addQuerySegment(QuerySegment.KeyValue(id, load.toString))).now
+        val resp = HttpClient.getTextResponse(s"$baseUrl?$id=$load", failOnError = false).now
+        val status = resp.status
+        val body = resp.fields.body
 
-        if responseMetadata.isRedirect then
+        if status.isRedirect then
           Async.delay(1.seconds)(reporter(id)).now
-        else if responseMetadata.isSuccess then
-          maybeResponseBody
+        else if status.isSuccess then
+          body
         else
-          Abort.fail(FailedRequest(maybeResponseBody)).now
+          Abort.fail(HttpStatusException(status, "GET", baseUrl, body)).now
 
     direct:
       val id = Random.nextStringAlphanumeric(8).now
       val (_, result) = Async.zip(blocker(id), reporter(id)).now
       result
 
-  def scenario11(scenarioUrl: Int => Uri) =
+  def scenario11(scenarioUrl: Int => String) =
     val url = scenarioUrl(11)
-    val req = Requests(_.get(url))
+    val req = HttpClient.getText(url)
     Async.race(Async.race(req, req), req)
 
-  def scenarioUrl(scenario: Int) = uri"http://localhost:8080/$scenario"
+  def scenarioUrl(scenario: Int) = s"http://localhost:8080/$scenario"
 
   def scenarios = Seq(scenario1, scenario2, scenario3, scenario4, scenario5, scenario6, scenario7, scenario8, scenario9, scenario10, scenario11)
 
   run:
-    Kyo.collect(scenarios.map(s => s(scenarioUrl)))
+    withClient:
+      Kyo.collectAll(scenarios.map(s => s(scenarioUrl)))

--- a/scala-kyo/src/test/scala/EasyRacerClientSpec.scala
+++ b/scala-kyo/src/test/scala/EasyRacerClientSpec.scala
@@ -5,7 +5,6 @@ import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.images.PullPolicy
-import sttp.client3.UriContext
 
 import scala.compiletime.uninitialized
 import scala.concurrent.{ExecutionContext, Future}
@@ -32,9 +31,17 @@ class EasyRacerClientSpec extends AsyncFlatSpec with Matchers with BeforeAndAfte
     container.stop()
     super.afterAll()
 
-  def scenarioUrl(scenario: Int) = uri"http://localhost:$port/$scenario"
+  def scenarioUrl(scenario: Int) = s"http://localhost:$port/$scenario"
 
   EasyRacerClient.scenarios.zipWithIndex.foreach: (fn, number) =>
     s"scenario ${number + 1}" should "work" in:
       import AllowUnsafe.embrace.danger
-      KyoApp.Unsafe.runAndBlock(1.minute)(fn(scenarioUrl)).getOrThrow.shouldBe("right")
+      // Each scenario gets its own HttpClient with a pool large enough for scenario 3's 10k racers,
+      // and a configuration that disables the 5s default timeout and auto-redirects (needed for
+      // scenarios 7 and 10).
+      val effect =
+        HttpClient.init(maxConnectionsPerHost = 10_100).map: client =>
+          HttpClient.let(client):
+            HttpClient.withConfig(_.timeout(Duration.Infinity).followRedirects(false)):
+              fn(scenarioUrl)
+      KyoApp.Unsafe.runAndBlock(2.minutes)(effect).getOrThrow.shouldBe("right")


### PR DESCRIPTION
## Summary

Kyo 1.0.0-RC2 retired `kyo-sttp` (the last published version was `1.0-RC1`) and shipped the new `kyo-http` module — a pure-Scala HTTP client/server with no Netty dependency. `kyo-core` also dropped its transitive SLF4J dependency in favor of explicit logging bridges. This PR migrates `scala-kyo` to that world.

## Changes

- **build.sbt**: drop `kyo-sttp 1.0-RC1`, add `kyo-http 1.0.0-RC2` and `kyo-logging-slf4j 1.0.0-RC2`.
- **EasyRacerClient.scala**: replace sttp `Requests`/`Uri` with `HttpClient.getText` and `HttpClient.getTextResponse`; drop the `uri""` interpolator in favor of plain `String` URLs. `HttpUrl.parse` preserves `rawQuery` verbatim, so scenarios 8 and 10 can still use value-less query parameters (`?open`, `?<id>`) by embedding them directly in the URL string.
- Replace `FailedRequest` (from sttp) with `HttpException` (from kyo-http).
- Rename `Resource.acquireRelease`/`Resource.run` to `Scope.acquireRelease`/`Scope.run`.
- Use `Kyo.collectAll` for sequencing the scenarios (`Kyo.collect` is now a filtering combinator).
- Wrap scenarios in `HttpClient.withConfig(_.timeout(Duration.Infinity).followRedirects(false))` because the default 5s timeout and auto-redirect behavior break scenarios 4/7/10.
- **EasyRacerClientSpec.scala**: each scenario now runs against its own `HttpClient.init(maxConnectionsPerHost = 10_100)` so that scenario 3's 10k racers don't exhaust the shared default pool and bleed connection state into later scenarios.

## Testing

All 11 scenarios pass locally against `ghcr.io/jamesward/easyracer:latest` (~27s wall-clock for the suite).