### PR TITLE
Add concurrency control to presos workflow

### DIFF
--- a/.github/workflows/presos.yaml
+++ b/.github/workflows/presos.yaml
@@ -10,7 +10,7 @@ on:
 # only allow one run at a time; queue new runs instead of running them concurrently
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build-and-upload:

--- a/.github/workflows/presos.yaml
+++ b/.github/workflows/presos.yaml
@@ -7,6 +7,11 @@ on:
     branches:
       - main
 
+# only allow one run at a time; queue new runs instead of running them concurrently
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Added concurrency configuration to the presos GitHub Actions workflow to ensure only one workflow run executes at a time, with new runs queued instead of running concurrently.

## Key Changes
- Added `concurrency` configuration block to the workflow
- Set concurrency group to `${{ github.workflow }}` to limit runs per workflow
- Disabled `cancel-in-progress` to preserve queued runs instead of canceling them

## Implementation Details
This change prevents multiple concurrent executions of the presos workflow, which can be useful for avoiding race conditions when building and uploading presentation artifacts. New workflow runs will be queued and executed sequentially rather than in parallel.

https://claude.ai/code/session_01TpLixH4jCMtiaxqL3epKVs